### PR TITLE
ESLint with Prettier

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
-// Babel configuration file
 {
   "presets": [
     ["@babel/preset-env", {

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,6 +1,7 @@
 # https://github.com/browserslist/browserslist#readme
 
->0.3%
+>0.3% and not dead
 defaults
 fully supports es6-module
 maintained node versions
+not op_mini all

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,8 +11,12 @@
   "parserOptions": {
     "ecmaVersion": "latest"
   },
+  "plugins": [
+    "compat"
+  ],
   "rules": {
     "no-console": "off",
+    "compat/compat": "error",
     "indent": [
       "error",
       "tab"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,5 +33,9 @@
       "error",
       "always"
     ]
+  },
+  "globals": {
+    "jQuery": "readonly",
+    "rsdWordPressVars": "readonly"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@wordpress/eslint-plugin/recommended"
+  ],
+  "overrides": [],
+  "parserOptions": {
+    "ecmaVersion": "latest"
+  },
+  "rules": {
+    "no-console": "off",
+    "indent": [
+      "error",
+      "tab"
+    ],
+    "linebreak-style": [
+      "error",
+      "unix"
+    ],
+    "quotes": [
+      "error",
+      "single"
+    ],
+    "semi": [
+      "error",
+      "always"
+    ]
+  }
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+.vscode/
+/build/
+/dist/
+node_modules/
+vendor/

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -191,7 +191,7 @@ class Plugin {
 		$localize_arr = array(
 			'defaultFilterLabels' => $labels,
 		);
-		wp_localize_script( self::get_plugin_name() . '-public', 'rsd_wordpress_vars', $localize_arr );
+		wp_localize_script( self::get_plugin_name() . '-public', 'rsdWordPressVars', $localize_arr );
 
 		// Get items from the API.
 		$items = Controller::get_items();

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "dev": "NODE_ENV=development vite build --watch",
     "build": "NODE_ENV=production vite build",
     "serve": "vite preview",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "eslint src/**/*.js",
+    "lint:fix": "eslint src/**/*.js --fix"
   },
   "keywords": [
     "research software directory",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "autoprefixer": "^10.4.19",
     "browserslist": "^4.23.0",
     "eslint": "^8.57.0",
+    "eslint-plugin-compat": "^4.2.0",
     "lightningcss": "^1.24.1",
     "postcss": "^8.4.38",
     "vite": "^5.2.9"

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "devDependencies": {
     "@babel/preset-env": "^7.24.4",
     "@rollup/plugin-babel": "^6.0.4",
-    "@wordpress/eslint-plugin": "^17.12.0",
-    "@wordpress/prettier-config": "^3.12.0",
+    "@wordpress/eslint-plugin": "^17.13.0",
+    "@wordpress/prettier-config": "^3.13.0",
     "autoprefixer": "^10.4.19",
     "browserslist": "^4.23.0",
     "eslint": "^8.57.0",
@@ -39,6 +39,6 @@
     "lightningcss": "^1.24.1",
     "postcss": "^8.4.38",
     "prettier": "npm:wp-prettier@^3.0.3",
-    "vite": "^5.2.9"
+    "vite": "^5.2.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,12 +31,14 @@
     "@babel/preset-env": "^7.24.4",
     "@rollup/plugin-babel": "^6.0.4",
     "@wordpress/eslint-plugin": "^17.12.0",
+    "@wordpress/prettier-config": "^3.12.0",
     "autoprefixer": "^10.4.19",
     "browserslist": "^4.23.0",
     "eslint": "^8.57.0",
     "eslint-plugin-compat": "^4.2.0",
     "lightningcss": "^1.24.1",
     "postcss": "^8.4.38",
+    "prettier": "npm:wp-prettier@^3.0.3",
     "vite": "^5.2.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
   "devDependencies": {
     "@babel/preset-env": "^7.24.4",
     "@rollup/plugin-babel": "^6.0.4",
+    "@wordpress/eslint-plugin": "^17.12.0",
     "autoprefixer": "^10.4.19",
     "browserslist": "^4.23.0",
+    "eslint": "^8.57.0",
     "lightningcss": "^1.24.1",
     "postcss": "^8.4.38",
     "vite": "^5.2.9"

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -681,10 +681,10 @@ jQuery(function ($) {
 
 	// Search field - attach search event and get new results from API.
 	// (executing with a slight delay after entry changes, so that the search term is not sent with every character)
-	var delayTimer;
+	let delayTimer;
 	$container.find('.rsd-search-input').on('input', function () {
 		clearTimeout(delayTimer);
-		var searchTerm = $(this).val().toLowerCase();
+		let searchTerm = $(this).val().toLowerCase();
 		delayTimer = setTimeout(function () {
 			console.log('🎹 searchTerm: ', searchTerm);
 			loadFilters();

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -119,7 +119,7 @@ jQuery(function ($) {
 				this.items = data.map(item => {
 					const label = item[this.getIdentifier()];
 					const count = item[this.getIdentifier() + '_cnt'] || 0;
-					return { name: label, count: count };
+					return { name: label, count };
 				});
 			}
 		}
@@ -217,7 +217,7 @@ jQuery(function ($) {
 			status: 'eq.approved',
 			is_published: 'eq.true',
 			limit: defaultLimit,
-			offset: offset,
+			offset,
 		};
 
 		if (orderBy) {
@@ -266,10 +266,9 @@ jQuery(function ($) {
 
 		// Get the data from the API.
 		return new Promise((resolve, reject) => {
-			const url = apiGetUrl(path, params);
 			const req = $.ajax({
 				type: 'GET',
-				url: url,
+				url: apiGetUrl(path, params),
 				headers: { 'Prefer': 'count=exact' },
 				success: function (response) {
 					const resultItems = response;

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-jQuery(function ($) {
+jQuery( function ( $ ) {
 	/*
 	Variables
 	*/
@@ -34,16 +34,16 @@ jQuery(function ($) {
 	};
 
 	// Get container element and section.
-	const $container = $('#rsd-wordpress');
-	const section = $container.data('section');
+	const $container = $( '#rsd-wordpress' );
+	const section = $container.data( 'section' );
 	const organisationId = $container.data( 'organisation_id' );
 
 	// Add a class to the body when the page is loaded.
-	$('body').addClass('rsd-wordpress-loaded');
+	$( 'body' ).addClass( 'rsd-wordpress-loaded' );
 	// Hide search button, since we're using the input event to trigger a search.
 	hideSearchButton();
 	// Check if any filters are set and show the 'Clear filters' button.
-	if (getSearchTerm() || Object.keys(getFilterValues()).length !== 0) {
+	if ( getSearchTerm() || Object.keys( getFilterValues() ).length !== 0 ) {
 		currentFilters = getFilterValues();
 		// (Re)load filters and items.
 		loadFilters();
@@ -60,14 +60,13 @@ jQuery(function ($) {
 	// Attach filters sidebar event handlers.
 	enhanceFiltersSidebar();
 
-
 	/*
 	Classes
 	*/
 
 	// Filter class
 	class Filter {
-		constructor(title, identifier, data = [], args = {}) {
+		constructor( title, identifier, data = [], args = {} ) {
 			const defaultArgs = {
 				placeholder: '',
 				showCount: true,
@@ -80,18 +79,18 @@ jQuery(function ($) {
 			this.args = { ...defaultArgs, ...args };
 
 			this.labels = {};
-			if (args.labels && Object.keys(args.labels).length !== 0) {
-				this.setLabels(args.labels);
+			if ( args.labels && Object.keys( args.labels ).length !== 0 ) {
+				this.setLabels( args.labels );
 			}
 
-			this.setItems(data);
+			this.setItems( data );
 		}
 
 		getTitle() {
 			return this.title;
 		}
 
-		getIdentifier(prefix = '') {
+		getIdentifier( prefix = '' ) {
 			return prefix + this.identifier;
 		}
 
@@ -99,28 +98,28 @@ jQuery(function ($) {
 			if ( labeledOnly || this.args.labeled_only ) {
 				const filterItems = [];
 				const labels = this.getLabels();
-				$.each(this.items, function (index, item) {
-					if (labels[item.name]) {
-						filterItems.push(item);
+				$.each( this.items, function ( index, item ) {
+					if ( labels[ item.name ] ) {
+						filterItems.push( item );
 					}
-				});
+				} );
 				return filterItems;
 			}
 
 			return this.items;
 		}
 
-		setItems(data) {
+		setItems( data ) {
 			this.items = [];
 
 			// Check if data is an array and not empty.
-			if (data && Array.isArray(data) && data.length !== 0) {
+			if ( data && Array.isArray( data ) && data.length !== 0 ) {
 				// Convert data to items.
-				this.items = data.map(item => {
-					const label = item[this.getIdentifier()];
-					const num = item[this.getIdentifier() + '_cnt'] || 0;
+				this.items = data.map( ( item ) => {
+					const label = item[ this.getIdentifier() ];
+					const num = item[ this.getIdentifier() + '_cnt' ] || 0;
 					return { name: label, count: num };
-				});
+				} );
 			}
 		}
 
@@ -130,7 +129,7 @@ jQuery(function ($) {
 			return this.args.placeholder || defaultPlaceholder;
 		}
 
-		setLabels(labels) {
+		setLabels( labels ) {
 			this.labels = labels;
 		}
 
@@ -138,50 +137,49 @@ jQuery(function ($) {
 			return this.labels;
 		}
 
-		getLabel(name) {
+		getLabel( name ) {
 			let label = name;
 
-			if (this.args.labels && this.args.labels[name]) {
-				label = this.args.labels[name];
+			if ( this.args.labels && this.args.labels[ name ] ) {
+				label = this.args.labels[ name ];
 			}
 
-			if (this.args.showCount) {
+			if ( this.args.showCount ) {
 				label += ' (' + this.getItemCount( name ) + ')';
 			}
 
 			return label;
 		}
 
-		getItemCount(name) {
+		getItemCount( name ) {
 			let count = 0;
 			// Find the item by name and return its count.
-			$.each(this.items, function (index, item) {
-				if (name === item.name) {
+			$.each( this.items, function ( index, item ) {
+				if ( name === item.name ) {
 					count = item.count;
 					return false; // exit the loop
 				}
-			});
+			} );
 			return count;
 		}
 
 		getValues() {
-			return this.items.map(item => item.name);
+			return this.items.map( ( item ) => item.name );
 		}
 	}
-
 
 	/*
 	API functions
 	*/
 
 	// Get the API URL.
-	function apiGetUrl(path, params = {}) {
+	function apiGetUrl( path, params = {} ) {
 		if (
 			params &&
 			typeof params === 'object' &&
 			Object.keys( params ).length !== 0
 		) {
-			path = path + '?' + $.param(params);
+			path = path + '?' + $.param( params );
 		}
 		return (
 			apiEndpoint + '/' + apiVersion + '/' + path.replace( /^\/+/, '' )
@@ -189,7 +187,7 @@ jQuery(function ($) {
 	}
 
 	// Get the API order string.
-	function apiGetOrder(orderBy, order) {
+	function apiGetOrder( orderBy, order ) {
 		const nullsLast = [
 			'mention_cnt',
 			'contributor_cnt',
@@ -198,13 +196,12 @@ jQuery(function ($) {
 			'date_start',
 			'date_end',
 		];
-		if (nullsLast.includes(orderBy)) {
-			return `${orderBy.toLowerCase()}.${order.toLowerCase()}.nullslast`;
+		if ( nullsLast.includes( orderBy ) ) {
+			return `${ orderBy.toLowerCase() }.${ order.toLowerCase() }.nullslast`;
 		}
 
-		return `${orderBy.toLowerCase()}.${order.toLowerCase()}`;
+		return `${ orderBy.toLowerCase() }.${ order.toLowerCase() }`;
 	}
-
 
 	/*
 	Controller functions
@@ -224,7 +221,7 @@ jQuery(function ($) {
 			: getSearchTerm();
 		filters = filters ? filters : getFilterValues();
 		orderBy = orderBy ? orderBy : getOrderBy();
-		order = order ? order : getOrder(orderBy);
+		order = order ? order : getOrder( orderBy );
 		offset = offset ? offset : 0;
 
 		// Hide the 'Clear filters' button if no search term or filters are set.
@@ -246,19 +243,19 @@ jQuery(function ($) {
 			offset: offset,
 		};
 
-		if (orderBy) {
-			params.order = apiGetOrder(orderBy, order);
+		if ( orderBy ) {
+			params.order = apiGetOrder( orderBy, order );
 		}
 
-		if (section === 'projects') {
-			if (searchTerm !== '') {
+		if ( section === 'projects' ) {
+			if ( searchTerm !== '' ) {
 				path = '/rpc/projects_by_organisation_search';
 				params.search = searchTerm;
 			} else {
 				path = '/rpc/projects_by_organisation';
 			}
-		} else if (section === 'software') {
-			if (searchTerm !== '') {
+		} else if ( section === 'software' ) {
+			if ( searchTerm !== '' ) {
 				path = '/rpc/software_by_organisation_search';
 				params.search = searchTerm;
 			} else {
@@ -276,11 +273,11 @@ jQuery(function ($) {
 			organisation: 'participating_organisations',
 		};
 
-		Object.keys(filterParamMap).forEach(filterKey => {
-			const paramKey = filterParamMap[filterKey];
-			const filterValue = filters[filterKey];
-			if (filterValue && filterValue.length > 0) {
-				if (paramKey === 'project_status') {
+		Object.keys( filterParamMap ).forEach( ( filterKey ) => {
+			const paramKey = filterParamMap[ filterKey ];
+			const filterValue = filters[ filterKey ];
+			if ( filterValue && filterValue.length > 0 ) {
+				if ( paramKey === 'project_status' ) {
 					params[ paramKey ] = `eq.${ filterValue
 						.flat()
 						.map( ( value ) => value.toLowerCase() ) }`;
@@ -293,39 +290,39 @@ jQuery(function ($) {
 						'}';
 				}
 			}
-		});
+		} );
 
-		console.log('🎹 path with params: ', apiGetUrl(path, params));
+		console.log( '🎹 path with params: ', apiGetUrl( path, params ) );
 
 		// Get the data from the API.
-		return new Promise((resolve, reject) => {
-			const req = $.ajax({
+		return new Promise( ( resolve, reject ) => {
+			const req = $.ajax( {
 				type: 'GET',
-				url: apiGetUrl(path, params),
+				url: apiGetUrl( path, params ),
 				headers: { Prefer: 'count=exact' },
 				// eslint-disable-next-line object-shorthand
-				success: function (response) {
+				success: function ( response ) {
 					const resultItems = response;
-					console.log('🎹 result items: ', resultItems);
+					console.log( '🎹 result items: ', resultItems );
 
 					// Get the total count of results from `content-range` response header.
 					let totalResults = false;
 					const contentRange =
 						req.getResponseHeader( 'content-range' );
-					if (contentRange) {
-						const total = contentRange.split('/');
-						totalResults = total[1];
-						itemsTotal = parseInt(totalResults);
+					if ( contentRange ) {
+						const total = contentRange.split( '/' );
+						totalResults = total[ 1 ];
+						itemsTotal = parseInt( totalResults );
 					}
 
-					resolve(resultItems);
+					resolve( resultItems );
 				},
 				// eslint-disable-next-line object-shorthand
-				error: function (jqXHR, textStatus, errorThrown) {
-					reject(errorThrown);
+				error: function ( jqXHR, textStatus, errorThrown ) {
+					reject( errorThrown );
 				},
-			});
-		});
+			} );
+		} );
 	}
 
 	// Get the filters from the API.
@@ -336,7 +333,7 @@ jQuery(function ($) {
 			organisation_id: organisationId,
 		};
 
-		if (getSearchTerm() !== '') {
+		if ( getSearchTerm() !== '' ) {
 			defaultParams.search_filter = getSearchTerm();
 		}
 
@@ -411,13 +408,13 @@ jQuery(function ($) {
 		};
 
 		// Build filters object for the current section, narrowed down by filter values.
-		const filterReqs = filtersDefault[section] || {};
+		const filterReqs = filtersDefault[ section ] || {};
 		const filterValues = getFilterValues();
 		const requests = [];
 
 		// Add any filter values to the filter requests.
-		Object.keys(filterReqs).forEach(filter => {
-			Object.keys(filterValues).forEach(valueId => {
+		Object.keys( filterReqs ).forEach( ( filter ) => {
+			Object.keys( filterValues ).forEach( ( valueId ) => {
 				if (
 					valueId === 'project_status' &&
 					filter === 'project_status'
@@ -426,9 +423,9 @@ jQuery(function ($) {
 					return;
 				}
 
-				const param = filterReqs[valueId].filter_as_param || false;
-				if (param) {
-					if (valueId === 'project_status') {
+				const param = filterReqs[ valueId ].filter_as_param || false;
+				if ( param ) {
+					if ( valueId === 'project_status' ) {
 						filterReqs[ filter ].params[ param ] =
 							filterValues[ valueId ][ 0 ] || '';
 					} else {
@@ -436,20 +433,20 @@ jQuery(function ($) {
 							filterValues[ valueId ];
 					}
 				}
-			});
-		});
+			} );
+		} );
 
 		// Get filter data from the API for each filter.
-		Object.entries(filterReqs).forEach(([filter, data]) => {
-			const promise = new Promise((resolve, reject) => {
-				$.ajax({
+		Object.entries( filterReqs ).forEach( ( [ filter, data ] ) => {
+			const promise = new Promise( ( resolve, reject ) => {
+				$.ajax( {
 					type: 'POST',
-					url: apiGetUrl(data.path),
-					data: JSON.stringify(data.params),
+					url: apiGetUrl( data.path ),
+					data: JSON.stringify( data.params ),
 					dataType: 'json',
 					contentType: 'application/json',
 					// eslint-disable-next-line object-shorthand
-					success: function (response) {
+					success: function ( response ) {
 						filters[ filter ] = new Filter(
 							data.title,
 							data.identifier,
@@ -459,20 +456,19 @@ jQuery(function ($) {
 						resolve();
 					},
 					// eslint-disable-next-line object-shorthand
-					error: function (jqXHR, textStatus, errorThrown) {
-						reject(errorThrown);
+					error: function ( jqXHR, textStatus, errorThrown ) {
+						reject( errorThrown );
 					},
-				});
-			});
+				} );
+			} );
 
-			requests.push(promise);
-		});
+			requests.push( promise );
+		} );
 
-		return Promise.all(requests).then(() => {
+		return Promise.all( requests ).then( () => {
 			return filters;
-		});
+		} );
 	}
-
 
 	/*
 	Wrappers
@@ -493,17 +489,17 @@ jQuery(function ($) {
 			currentOffset = offset + items.length;
 
 			// Display the results.
-			displayResults(items, itemsTotal);
+			displayResults( items, itemsTotal );
 			// Re-attach infinite scroll event.
 			enhanceResultsInfiniteScroll();
-		} catch (error) {
-			console.error('🎹 Error fetching items: ', error);
+		} catch ( error ) {
+			console.error( '🎹 Error fetching items: ', error );
 		}
 	}
 
 	// Load more items.
 	async function loadMoreItems() {
-		if (!hasMoreItems()) {
+		if ( ! hasMoreItems() ) {
 			return;
 		}
 
@@ -517,14 +513,14 @@ jQuery(function ($) {
 				getOrder(),
 				offset
 			);
-			items = items.concat(newItems);
+			items = items.concat( newItems );
 			currentOffset = offset + newItems.length;
 
 			// Append the results.
 			const appendItems = true;
-			displayResults(newItems, itemsTotal, appendItems);
-		} catch (error) {
-			console.error('🎹 Error fetching more items: ', error);
+			displayResults( newItems, itemsTotal, appendItems );
+		} catch ( error ) {
+			console.error( '🎹 Error fetching more items: ', error );
 		}
 	}
 
@@ -536,84 +532,83 @@ jQuery(function ($) {
 	// Load filters
 	async function loadFilters() {
 		fetchFilters()
-			.then(filters => {
-				displayUpdateFilterValues(filters);
+			.then( ( filters ) => {
+				displayUpdateFilterValues( filters );
 				return filters;
-			})
-			.catch(error => {
-				console.error('🎹 Error fetching filters: ', error);
-			});
+			} )
+			.catch( ( error ) => {
+				console.error( '🎹 Error fetching filters: ', error );
+			} );
 	}
-
 
 	/*
 	Item functions
 	*/
 
-	function getItemId(item) {
+	function getItemId( item ) {
 		return item.id;
 	}
 
-	function getItemSlugFromURL(url) {
-		return url.split('/').pop();
+	function getItemSlugFromURL( url ) {
+		return url.split( '/' ).pop();
 	}
 
-	function getItemUrl(item) {
-		return `https://research-software-directory.org/${section}/${item.slug}`;
+	function getItemUrl( item ) {
+		return `https://research-software-directory.org/${ section }/${ item.slug }`;
 	}
 
-	function getItemImgUrl(item) {
-		if (item.image_id) {
-			return `https://research-software-directory.org/image/rpc/get_image?uid=${item.image_id}`;
+	function getItemImgUrl( item ) {
+		if ( item.image_id ) {
+			return `https://research-software-directory.org/image/rpc/get_image?uid=${ item.image_id }`;
 		}
 
 		return 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'; // Transparent 1x1 GIF
 	}
 
-	function getItemImageContain(item) {
-		if (item.image_contain) {
+	function getItemImageContain( item ) {
+		if ( item.image_contain ) {
 			return item.image_contain;
 		}
 		return false;
 	}
 
-	function getItemContributorsCount(item) {
+	function getItemContributorsCount( item ) {
 		return item.contributor_cnt || 0;
 	}
 
-	function getItemMentionsCount(item) {
+	function getItemMentionsCount( item ) {
 		return item.mention_cnt || 0;
 	}
 
-	function getItemImpactCount(item) {
+	function getItemImpactCount( item ) {
 		return item.impact_cnt || 0;
 	}
 
-	function getItemOutputCount(item) {
+	function getItemOutputCount( item ) {
 		return item.output_cnt || 0;
 	}
 
-	function getItemLabels(item) {
+	function getItemLabels( item ) {
 		let html = '<ul class="rsd-results-item-labels">';
-		$.each(item.keywords, function (index, label) {
-			html += `<li class="label">${label}</li>`;
-		});
+		$.each( item.keywords, function ( index, label ) {
+			html += `<li class="label">${ label }</li>`;
+		} );
 		html += '</ul>';
 
 		return html;
 	}
 
-	function getItemProps(item, props) {
+	function getItemProps( item, props ) {
 		let html = '<ul class="rsd-results-item-props">';
-		$.each(props, function (prop, value) {
+		$.each( props, function ( prop, value ) {
 			html += `
-				<li class="rsd-results-item-prop-${prop.toLowerCase()}">
-					<span aria-hidden="true" class="icon icon-${prop.toLowerCase()}" title="${prop}"></span>
-					<span class="value">${value}</span>
-					<span class="prop">${prop.toLowerCase()}</span>
+				<li class="rsd-results-item-prop-${ prop.toLowerCase() }">
+					<span aria-hidden="true" class="icon icon-${ prop.toLowerCase() }" title="${ prop }"></span>
+					<span class="value">${ value }</span>
+					<span class="prop">${ prop.toLowerCase() }</span>
 				</li>
 			`;
-		});
+		} );
 		html += '</ul>';
 
 		return html;
@@ -628,29 +623,29 @@ jQuery(function ($) {
 			'output_cnt',
 		];
 
-		$container.find('.rsd-results-item').each(function () {
-			const $item = $(this);
+		$container.find( '.rsd-results-item' ).each( function () {
+			const $item = $( this );
 			const item = {
-				id: $item.data('id'),
-				title: $item.find('h3').text(),
-				description: $item.find('.card-section p').text(),
-				slug: getItemSlugFromURL($item.find('h3 a').attr('href')),
+				id: $item.data( 'id' ),
+				title: $item.find( 'h3' ).text(),
+				description: $item.find( '.card-section p' ).text(),
+				slug: getItemSlugFromURL( $item.find( 'h3 a' ).attr( 'href' ) ),
 				labels: [],
 			};
-			$item.find('.rsd-results-item-props li').each(function () {
+			$item.find( '.rsd-results-item-props li' ).each( function () {
 				const prop =
 					$( this )
 						.attr( 'class' )
 						.replace( 'rsd-results-item-prop-', '' )
 						.trim() + '_cnt';
-				const value = parseInt($(this).find('.value').text());
-				if (validProps.includes(prop)) {
-					item[prop] = value;
+				const value = parseInt( $( this ).find( '.value' ).text() );
+				if ( validProps.includes( prop ) ) {
+					item[ prop ] = value;
 				}
-			});
+			} );
 
-			domItems.push(item);
-		});
+			domItems.push( item );
+		} );
 		return domItems;
 	}
 
@@ -658,26 +653,24 @@ jQuery(function ($) {
 		const count = $container
 			.find( '.rsd-results-count' )
 			.data( 'items-total' );
-		return parseInt(count);
+		return parseInt( count );
 	}
-
 
 	/*
 	Filter functions
 	*/
 
-	function setCurrentFilters(filter, value) {
-		if (!Array.isArray(value)) {
-			currentFilters[filter] = [value];
+	function setCurrentFilters( filter, value ) {
+		if ( ! Array.isArray( value ) ) {
+			currentFilters[ filter ] = [ value ];
 		} else {
-			currentFilters[filter] = value;
+			currentFilters[ filter ] = value;
 		}
 	}
 
 	function clearCurrentFilters() {
 		currentFilters = {};
 	}
-
 
 	/*
 	Form functions
@@ -700,7 +693,7 @@ jQuery(function ($) {
 		return orderBy || false;
 	}
 
-	function getOrder(orderBy = false) {
+	function getOrder( orderBy = false ) {
 		const sortDesc = [
 			'mention_cnt',
 			'contributor_cnt',
@@ -709,7 +702,7 @@ jQuery(function ($) {
 			'updated_at',
 			'date_end',
 		];
-		if (orderBy && sortDesc.includes(orderBy)) {
+		if ( orderBy && sortDesc.includes( orderBy ) ) {
 			return 'desc';
 		}
 
@@ -718,54 +711,52 @@ jQuery(function ($) {
 
 	function getFilterValues() {
 		const filters = {};
-		$container.find('.rsd-filters select').each(function () {
-			const $filter = $(this);
-			const identifier = $filter.data('filter');
+		$container.find( '.rsd-filters select' ).each( function () {
+			const $filter = $( this );
+			const identifier = $filter.data( 'filter' );
 			const value = $filter.val();
-			if (value && value !== '') {
-				filters[identifier] = [value];
+			if ( value && value !== '' ) {
+				filters[ identifier ] = [ value ];
 			}
-		});
+		} );
 		return filters;
 	}
-
 
 	/*
 	UI functions
 	*/
 
 	function hideSearchButton() {
-		$container.find('.rsd-search-bar input[type="submit"]').hide();
+		$container.find( '.rsd-search-bar input[type="submit"]' ).hide();
 	}
 
 	function showClearFiltersButton() {
-		$container.find('.rsd-results-clear-filters').show();
+		$container.find( '.rsd-results-clear-filters' ).show();
 	}
 
 	function hideClearFiltersButton() {
-		$container.find('.rsd-results-clear-filters').hide();
+		$container.find( '.rsd-results-clear-filters' ).hide();
 	}
 
 	function hideFiltersSidebar() {
-		$container.find('.rsd-filter-sidebar').hide();
+		$container.find( '.rsd-filter-sidebar' ).hide();
 	}
 
 	function toggleFiltersSidebar() {
-		const $sidebar = $container.find('.rsd-filter-sidebar');
-		const $button = $container.find('.rsd-filter-button button');
+		const $sidebar = $container.find( '.rsd-filter-sidebar' );
+		const $button = $container.find( '.rsd-filter-button button' );
 		$sidebar.toggle();
 
-		if ($sidebar.is(':visible')) {
-			$button.addClass('active');
+		if ( $sidebar.is( ':visible' ) ) {
+			$button.addClass( 'active' );
 		} else {
-			$button.removeClass('active');
+			$button.removeClass( 'active' );
 		}
 	}
 
 	function hideShowMoreButton() {
-		$container.find('.rsd-results-show-more .button').hide();
+		$container.find( '.rsd-results-show-more .button' ).hide();
 	}
-
 
 	/*
 	Event handlers
@@ -774,37 +765,37 @@ jQuery(function ($) {
 	// Search field - attach search event and get new results from API.
 	// (executing with a slight delay after entry changes, so that the search term is not sent with every character)
 	let delayTimer;
-	$container.find('.rsd-search-input').on('input', function () {
-		clearTimeout(delayTimer);
-		const searchTerm = $(this).val().toLowerCase();
-		delayTimer = setTimeout(function () {
-			console.log('🎹 searchTerm: ', searchTerm);
+	$container.find( '.rsd-search-input' ).on( 'input', function () {
+		clearTimeout( delayTimer );
+		const searchTerm = $( this ).val().toLowerCase();
+		delayTimer = setTimeout( function () {
+			console.log( '🎹 searchTerm: ', searchTerm );
 			loadFilters();
-			loadItems(searchTerm);
-			if (searchTerm.trim() === '') {
+			loadItems( searchTerm );
+			if ( searchTerm.trim() === '' ) {
 				hideClearFiltersButton();
 			} else {
 				showClearFiltersButton();
 			}
-		}, 500);
-	});
+		}, 500 );
+	} );
 
 	// Attach set filters event and get new results from API.
-	$container.find('.rsd-filters').on('change', 'select', function () {
-		setCurrentFilters($(this).data('filter'), $(this).val());
+	$container.find( '.rsd-filters' ).on( 'change', 'select', function () {
+		setCurrentFilters( $( this ).data( 'filter' ), $( this ).val() );
 		loadFilters();
 		loadItems();
-		if (Object.keys(getFilterValues()).length === 0) {
+		if ( Object.keys( getFilterValues() ).length === 0 ) {
 			hideClearFiltersButton();
 		}
-	});
+	} );
 
 	// Attach click event to 'Clear filters' button and get new results from API.
-	$container.find('.rsd-results-clear-filters').on('click', clearFilters);
+	$container.find( '.rsd-results-clear-filters' ).on( 'click', clearFilters );
 
 	function clearFilters() {
-		$container.find('.rsd-search-input').val('');
-		$container.find('.rsd-filters select').val('');
+		$container.find( '.rsd-search-input' ).val( '' );
+		$container.find( '.rsd-filters select' ).val( '' );
 		clearCurrentFilters();
 		loadFilters();
 		loadItems();
@@ -818,35 +809,35 @@ jQuery(function ($) {
 
 	// Enhance filters sidebar.
 	function enhanceFiltersSidebar() {
-		const $sidebar = $container.find('.rsd-filter-sidebar');
+		const $sidebar = $container.find( '.rsd-filter-sidebar' );
 
 		// Add close button to filters sidebar.
-		$sidebar.prepend(`
+		$sidebar.prepend( `
 			<button class="close-button" aria-label="Close alert" type="button"
 				<span aria-hidden="true">&times;</span>
 			</button>
-		`);
+		` );
 
-		$sidebar.find('.close-button').on('click', toggleFiltersSidebar);
+		$sidebar.find( '.close-button' ).on( 'click', toggleFiltersSidebar );
 	}
 
 	// Attach change event to sort by select.
-	$container.find('.rsd-sortby-input').on('change', function () {
+	$container.find( '.rsd-sortby-input' ).on( 'change', function () {
 		loadItems();
-	});
+	} );
 
 	// Attach infinite scroll event that automatically loads more results (if any).
 	function enhanceResultsInfiniteScroll() {
-		if (IntersectionObserver === undefined) {
+		if ( IntersectionObserver === undefined ) {
 			return false;
 		}
 
-		const targetElement = $('.rsd-results-show-more')[0];
+		const targetElement = $( '.rsd-results-show-more' )[ 0 ];
 
-		if (scrollObserver) {
+		if ( scrollObserver ) {
 			// Continue observing the target element.
-			if (hasMoreItems()) {
-				scrollObserver.observe(targetElement);
+			if ( hasMoreItems() ) {
+				scrollObserver.observe( targetElement );
 			}
 		} else {
 			// Start observing the target element.
@@ -862,13 +853,13 @@ jQuery(function ($) {
 				}
 			);
 
-			scrollObserver.observe(targetElement);
+			scrollObserver.observe( targetElement );
 		}
 
 		return true;
 	}
 
-	if (enhanceResultsInfiniteScroll()) {
+	if ( enhanceResultsInfiniteScroll() ) {
 		hideShowMoreButton();
 	}
 
@@ -878,53 +869,52 @@ jQuery(function ($) {
 		.on( 'click', loadMoreItems );
 
 	// Attach back to top button scroll handler and execute on page load.
-	$(window).on('scroll', enhanceBackToTopButton);
+	$( window ).on( 'scroll', enhanceBackToTopButton );
 	enhanceBackToTopButton();
 
 	function enhanceBackToTopButton() {
 		const offset = $container.offset().top || 100;
-		const $button = $container.find('.rsd-back-to-top');
+		const $button = $container.find( '.rsd-back-to-top' );
 
-		if ($(window).scrollTop() > offset) {
-			$button.addClass('visible');
+		if ( $( window ).scrollTop() > offset ) {
+			$button.addClass( 'visible' );
 		} else {
-			$button.removeClass('visible');
+			$button.removeClass( 'visible' );
 		}
 	}
 
-	$container.find('.rsd-back-to-top a').on('click', function () {
-		$('html, body').animate({ scrollTop: 0 }, 400);
+	$container.find( '.rsd-back-to-top a' ).on( 'click', function () {
+		$( 'html, body' ).animate( { scrollTop: 0 }, 400 );
 		return false;
-	});
-
+	} );
 
 	/*
 	Display functions
 	*/
 
 	// Update the result count.
-	function displaySetResultsTotalCount(count) {
+	function displaySetResultsTotalCount( count ) {
 		$container
 			.find( '.rsd-results-count' )
 			.text( `${ count } items found` );
 	}
 
 	// Update filters.
-	function displayUpdateFilterValues(filters) {
-		$.each(filters, function (identifier, filter) {
+	function displayUpdateFilterValues( filters ) {
+		$.each( filters, function ( identifier, filter ) {
 			const $filter = $container.find(
 				`.rsd-filters select[data-filter="${ identifier }"]`
 			);
 			// Get first placeholder item.
-			const $placeholder = $filter.find('.placeholder');
+			const $placeholder = $filter.find( '.placeholder' );
 			// Clear the filter.
 			$filter.empty();
 			// Add the placeholder item back and add the new filter values.
-			$filter.append($placeholder);
+			$filter.append( $placeholder );
 			// Add the new filter values.
-			filter.getItems().forEach(function (item) {
+			filter.getItems().forEach( function ( item ) {
 				const value = item.name;
-				const label = filter.getLabel(value);
+				const label = filter.getLabel( value );
 				let selected = '';
 				if (
 					currentFilters[ identifier ] &&
@@ -935,8 +925,8 @@ jQuery(function ($) {
 				$filter.append(
 					`<option value="${ value }"${ selected }>${ label }</option>`
 				);
-			});
-		});
+			} );
+		} );
 	}
 
 	// Display the results.
@@ -946,30 +936,30 @@ jQuery(function ($) {
 		appendItems = false
 	) {
 		// Get the results container.
-		const $itemsContainer = $container.find('.rsd-results-items');
+		const $itemsContainer = $container.find( '.rsd-results-items' );
 
 		// Empty results container if no items are provided.
 		if (
-			!displayItems ||
-			!Array.isArray(displayItems) ||
+			! displayItems ||
+			! Array.isArray( displayItems ) ||
 			displayItems.length === 0
 		) {
 			$itemsContainer.empty();
-			displaySetResultsTotalCount(0);
+			displaySetResultsTotalCount( 0 );
 			return false;
 		}
 
 		// Update result count.
-		displaySetResultsTotalCount(totalCount || '-');
+		displaySetResultsTotalCount( totalCount || '-' );
 
 		// Clear the results container.
-		if (!appendItems) {
+		if ( ! appendItems ) {
 			$itemsContainer.empty();
 		}
 
-		$.each(displayItems, function (index, item) {
+		$.each( displayItems, function ( index, item ) {
 			let title, description, props;
-			if ('projects' === section) {
+			if ( 'projects' === section ) {
 				title = item.title;
 				description = item.subtitle;
 				props = {
@@ -986,33 +976,32 @@ jQuery(function ($) {
 			}
 
 			let imageContainAttr = '';
-			if (getItemImageContain(item)) {
+			if ( getItemImageContain( item ) ) {
 				imageContainAttr = ' class="contain"';
 			}
 
-			$itemsContainer.append(`
-				<div class="rsd-results-item column card in-viewport" data-id="${getItemId(item)}">
+			$itemsContainer.append( `
+				<div class="rsd-results-item column card in-viewport" data-id="${ getItemId( item ) }">
 					<div class="card-image">
-						<a href="${getItemUrl(item)}" target="_blank" rel="external"><img src="${getItemImgUrl(item)}"
-							 alt="" title="${title}" aria-label="${title}"${imageContainAttr}></a>
+						<a href="${ getItemUrl( item ) }" target="_blank" rel="external"><img src="${ getItemImgUrl( item ) }"
+							 alt="" title="${ title }" aria-label="${ title }"${ imageContainAttr }></a>
 					</div>
 					<div class="card-section">
-						<h3><a href="${getItemUrl(item)}" target="_blank" rel="external">${title}</a></h3>
-						<p>${description}</p>
+						<h3><a href="${ getItemUrl( item ) }" target="_blank" rel="external">${ title }</a></h3>
+						<p>${ description }</p>
 					</div>
 					<div class="card-footer">
 						<div class="rsd-results-item-specs">
-							${getItemLabels(item)}
+							${ getItemLabels( item ) }
 						</div>
 						<div class="rsd-results-item-props">
-							${getItemProps(item, props)}
+							${ getItemProps( item, props ) }
 						</div>
 					</div>
 				</div>
-			`);
-		});
+			` );
+		} );
 
 		return true;
 	}
-
-});
+} );

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -25,11 +25,11 @@ jQuery(function ($) {
 	// Default parameters
 	const defaultLimit = 48;
 	const defaultFilterLabels = rsdWordPressVars.defaultFilterLabels || {
-		'project_status': {
-			'upcoming'    : 'Upcoming',
-			'in_progress' : 'In progress',
-			'finished'    : 'Finished',
-			'unknown'     : 'Unknown'
+		project_status: {
+			upcoming: 'Upcoming',
+			in_progress: 'In progress',
+			finished: 'Finished',
+			unknown: 'Unknown',
 		}
 	};
 
@@ -270,7 +270,7 @@ jQuery(function ($) {
 			const req = $.ajax({
 				type: 'GET',
 				url: apiGetUrl(path, params),
-				headers: { 'Prefer': 'count=exact' },
+				headers: { Prefer: 'count=exact' },
 				// eslint-disable-next-line object-shorthand
 				success: function (response) {
 					const resultItems = response;
@@ -308,8 +308,8 @@ jQuery(function ($) {
 		}
 
 		const filtersDefault = {
-			'projects': {
-				'project_status': {
+			projects: {
+				project_status: {
 					title: 'Project status',
 					identifier: 'project_status',
 					args: { ...defaultArgs, labels: { ...defaultFilterLabels.project_status } },
@@ -317,7 +317,7 @@ jQuery(function ($) {
 					path: '/rpc/org_project_status_filter?order=project_status',
 					params: { ...defaultParams }
 				},
-				'keyword': {
+				keyword: {
 					title: 'Keywords',
 					identifier: 'keyword',
 					args: { ...defaultArgs },
@@ -325,7 +325,7 @@ jQuery(function ($) {
 					path: '/rpc/org_project_keywords_filter?order=keyword',
 					params: { ...defaultParams }
 				},
-				'domain': {
+				domain: {
 					title: 'Research domains',
 					identifier: 'domain',
 					args: { ...defaultArgs, labeled_only: true, labels: { ...defaultFilterLabels.domain } },
@@ -333,7 +333,7 @@ jQuery(function ($) {
 					path: '/rpc/org_project_domains_filter?order=domain',
 					params: { ...defaultParams }
 				},
-				'organisation': {
+				organisation: {
 					title: 'Partners',
 					identifier: 'organisation',
 					args: { ...defaultArgs },
@@ -342,8 +342,8 @@ jQuery(function ($) {
 					params: { ...defaultParams }
 				}
 			},
-			'software': {
-				'keyword': {
+			software: {
+				keyword: {
 					title: 'Keywords',
 					identifier: 'keyword',
 					args: { ...defaultArgs },
@@ -351,7 +351,7 @@ jQuery(function ($) {
 					path: '/rpc/org_software_keywords_filter?order=keyword',
 					params: { ...defaultParams }
 				},
-				'prog_language': {
+				prog_language: {
 					title: 'Programming Languages',
 					identifier: 'prog_language',
 					args: { ...defaultArgs },
@@ -359,7 +359,7 @@ jQuery(function ($) {
 					path: '/rpc/org_software_languages_filter?order=prog_language',
 					params: { ...defaultParams }
 				},
-				'license': {
+				license: {
 					title: 'Licenses',
 					identifier: 'license',
 					args: { ...defaultArgs },
@@ -871,15 +871,15 @@ jQuery(function ($) {
 				title = item.title;
 				description = item.subtitle;
 				props = {
-					'Impact': getItemImpactCount(item),
-					'Output': getItemOutputCount(item),
+					Impact: getItemImpactCount( item ),
+					Output: getItemOutputCount( item ),
 				};
 			} else {
 				title = item.brand_name;
 				description = item.short_statement;
 				props = {
-					'Contributors': getItemContributorsCount(item),
-					'Mentions': getItemMentionsCount(item),
+					Contributors: getItemContributorsCount( item ),
+					Mentions: getItemMentionsCount( item ),
 				};
 			}
 

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -36,7 +36,7 @@ jQuery(function ($) {
 	// Get container element and section.
 	const $container = $('#rsd-wordpress');
 	const section = $container.data('section');
-	const organisation_id = $container.data('organisation_id');
+	const organisationId = $container.data( 'organisation_id' );
 
 	// Add a class to the body when the page is loaded.
 	$('body').addClass('rsd-wordpress-loaded');
@@ -95,13 +95,13 @@ jQuery(function ($) {
 			return prefix + this.identifier;
 		}
 
-		getItems(labeled_only = false) {
-			if (labeled_only || this.args.labeled_only) {
 				let items = [];
 				let labels = this.getLabels();
 				$.each(this.items, function (index, item) {
 					if (labels[item.name]) {
 						items.push(item);
+		getItems( labeledOnly = false ) {
+			if ( labeledOnly || this.args.labeled_only ) {
 					}
 				});
 				return items;
@@ -213,7 +213,7 @@ jQuery(function ($) {
 		// Build the API URL based on section.
 		let path = '';
 		let params = {
-			organisation_id: organisation_id,
+			organisation_id: organisationId,
 			status: 'eq.approved',
 			is_published: 'eq.true',
 			limit: defaultLimit,
@@ -300,7 +300,7 @@ jQuery(function ($) {
 		let filters = {};
 		let defaultArgs = {};
 		let defaultParams = {
-			'organisation_id': organisation_id,
+			organisation_id: organisationId,
 		};
 
 		if (getSearchTerm() !== '') {

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -881,7 +881,7 @@ jQuery(function ($) {
 
 			let imageContainAttr = '';
 			if (getItemImageContain(item)) {
-				imageContainAttr = ` class="contain"`;
+				imageContainAttr = ' class="contain"';
 			}
 
 			$itemsContainer.append(`

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -26,13 +26,13 @@ jQuery(function($) {
 	const apiVersion = 'v1';
 	// Default parameters
 	const defaultLimit = 48;
-	const defaultFilterLabels = rsd_wordpress_vars.defaultFilterLabels || {
 		'project_status': {
 			'upcoming'    : 'Upcoming',
 			'in_progress' : 'In progress',
 			'finished'    : 'Finished',
 			'unknown'     : 'Unknown'
 		}
+	const defaultFilterLabels = rsdWordPressVars.defaultFilterLabels || {
 	};
 
 	// Get container element and section.

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -270,6 +270,7 @@ jQuery(function ($) {
 				type: 'GET',
 				url: apiGetUrl(path, params),
 				headers: { 'Prefer': 'count=exact' },
+				// eslint-disable-next-line object-shorthand
 				success: function (response) {
 					const resultItems = response;
 					console.log('🎹 result items: ', resultItems);
@@ -285,6 +286,7 @@ jQuery(function ($) {
 
 					resolve(resultItems);
 				},
+				// eslint-disable-next-line object-shorthand
 				error: function (jqXHR, textStatus, errorThrown) {
 					reject(errorThrown);
 				},
@@ -400,10 +402,12 @@ jQuery(function ($) {
 					data: JSON.stringify(data.params),
 					dataType: 'json',
 					contentType: 'application/json',
+					// eslint-disable-next-line object-shorthand
 					success: function (response) {
 						filters[filter] = new Filter(data.title, data.identifier, response, data.args);
 						resolve();
 					},
+					// eslint-disable-next-line object-shorthand
 					error: function (jqXHR, textStatus, errorThrown) {
 						reject(errorThrown);
 					},

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -97,14 +97,14 @@ jQuery(function ($) {
 
 		getItems( labeledOnly = false ) {
 			if ( labeledOnly || this.args.labeled_only ) {
-				const items = [];
+				const filterItems = [];
 				const labels = this.getLabels();
 				$.each(this.items, function (index, item) {
 					if (labels[item.name]) {
-						items.push(item);
+						filterItems.push(item);
 					}
 				});
-				return items;
+				return filterItems;
 			} else {
 				return this.items;
 			}
@@ -556,7 +556,7 @@ jQuery(function ($) {
 	}
 
 	function getItemsFromDOM() {
-		const items = [];
+		const domItems = [];
 		const validProps = ['contributor_cnt', 'mention_cnt', 'impact_cnt', 'output_cnt'];
 
 		$container.find('.rsd-results-item').each(function () {
@@ -576,9 +576,9 @@ jQuery(function ($) {
 				}
 			});
 
-			items.push(item);
+			domItems.push(item);
 		});
-		return items;
+		return domItems;
 	}
 
 	function getItemsTotalFromDOM() {

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -1,10 +1,9 @@
 /**
  * RSD WordPress plugin JavaScript
  *
- * @package RSD_WP
+ * @module rsd-wordpress
  * @since 0.4.0
  * @license Apache-2.0
- * @link https://research-software-directory.org
  */
 
 'use strict';

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -118,8 +118,8 @@ jQuery(function ($) {
 				// Convert data to items.
 				this.items = data.map(item => {
 					const label = item[this.getIdentifier()];
-					const count = item[this.getIdentifier() + '_cnt'] || 0;
-					return { name: label, count: count };
+					const num = item[this.getIdentifier() + '_cnt'] || 0;
+					return { name: label, count: num };
 				});
 			}
 		}
@@ -217,6 +217,7 @@ jQuery(function ($) {
 			status: 'eq.approved',
 			is_published: 'eq.true',
 			limit: defaultLimit,
+			// eslint-disable-next-line object-shorthand
 			offset: offset,
 		};
 
@@ -266,10 +267,9 @@ jQuery(function ($) {
 
 		// Get the data from the API.
 		return new Promise((resolve, reject) => {
-			const url = apiGetUrl(path, params);
 			const req = $.ajax({
 				type: 'GET',
-				url: url,
+				url: apiGetUrl(path, params),
 				headers: { 'Prefer': 'count=exact' },
 				// eslint-disable-next-line object-shorthand
 				success: function (response) {

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -723,7 +723,7 @@ jQuery(function ($) {
 	$container.find('.rsd-filter-button button').on('click', toggleFiltersSidebar);
 
 	// Enhance filters sidebar.
-	function enhanceFiltersSidebar(filters) {
+	function enhanceFiltersSidebar() {
 		const $sidebar = $container.find('.rsd-filter-sidebar');
 
 		// Add close button to filters sidebar.

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -8,8 +8,7 @@
 
 'use strict';
 
-jQuery(function($) {
-
+jQuery(function ($) {
 	/*
 	Variables
 	*/
@@ -25,13 +24,13 @@ jQuery(function($) {
 	const apiVersion = 'v1';
 	// Default parameters
 	const defaultLimit = 48;
+	const defaultFilterLabels = rsdWordPressVars.defaultFilterLabels || {
 		'project_status': {
 			'upcoming'    : 'Upcoming',
 			'in_progress' : 'In progress',
 			'finished'    : 'Finished',
 			'unknown'     : 'Unknown'
 		}
-	const defaultFilterLabels = rsdWordPressVars.defaultFilterLabels || {
 	};
 
 	// Get container element and section.
@@ -100,7 +99,7 @@ jQuery(function($) {
 			if (labeled_only || this.args.labeled_only) {
 				let items = [];
 				let labels = this.getLabels();
-				$.each(this.items, function(index, item) {
+				$.each(this.items, function (index, item) {
 					if (labels[item.name]) {
 						items.push(item);
 					}
@@ -155,7 +154,7 @@ jQuery(function($) {
 		getItemCount(name) {
 			let count = 0;
 			// Find the item by name and return its count.
-			$.each(this.items, function(index, item) {
+			$.each(this.items, function (index, item) {
 				if (name === item.name) {
 					count = item.count;
 					return false; // exit the loop
@@ -274,7 +273,7 @@ jQuery(function($) {
 				type: 'GET',
 				url: url,
 				headers: { 'Prefer': 'count=exact' },
-				success: function(response) {
+				success: function (response) {
 					let resultItems = response;
 					console.log('🎹 result items: ', resultItems);
 
@@ -289,7 +288,7 @@ jQuery(function($) {
 
 					resolve(resultItems);
 				},
-				error: function(jqXHR, textStatus, errorThrown) {
+				error: function (jqXHR, textStatus, errorThrown) {
 					reject(errorThrown);
 				},
 			});
@@ -404,11 +403,11 @@ jQuery(function($) {
 					data: JSON.stringify(data.params),
 					dataType: 'json',
 					contentType: 'application/json',
-					success: function(response) {
+					success: function (response) {
 						filters[filter] = new Filter(data.title, data.identifier, response, data.args);
 						resolve();
 					},
-					error: function(jqXHR, textStatus, errorThrown) {
+					error: function (jqXHR, textStatus, errorThrown) {
 						reject(errorThrown);
 					},
 				});
@@ -532,7 +531,7 @@ jQuery(function($) {
 
 	function getItemLabels(item) {
 		let html = '<ul class="rsd-results-item-labels">';
-		$.each(item.keywords, function(index, label) {
+		$.each(item.keywords, function (index, label) {
 			html += `<li class="label">${label}</li>`;
 		});
 		html += '</ul>';
@@ -542,7 +541,7 @@ jQuery(function($) {
 
 	function getItemProps(item, props) {
 		let html = '<ul class="rsd-results-item-props">';
-		$.each(props, function(prop, value) {
+		$.each(props, function (prop, value) {
 			html += `
 				<li class="rsd-results-item-prop-${prop.toLowerCase()}">
 					<span aria-hidden="true" class="icon icon-${prop.toLowerCase()}" title="${prop}"></span>
@@ -560,7 +559,7 @@ jQuery(function($) {
 		let items = [];
 		let validProps = ['contributor_cnt', 'mention_cnt', 'impact_cnt', 'output_cnt'];
 
-		$container.find('.rsd-results-item').each(function() {
+		$container.find('.rsd-results-item').each(function () {
 			let $item = $(this);
 			let item = {
 				id: $item.data('id'),
@@ -569,7 +568,7 @@ jQuery(function($) {
 				slug: getItemSlugFromURL($item.find('h3 a').attr('href')),
 				labels: [],
 			};
-			$item.find('.rsd-results-item-props li').each(function() {
+			$item.find('.rsd-results-item-props li').each(function () {
 				let prop = $(this).attr('class').replace('rsd-results-item-prop-', '').trim() + '_cnt';
 				let value = parseInt($(this).find('.value').text());
 				if (validProps.includes(prop)) {
@@ -629,10 +628,10 @@ jQuery(function($) {
 
 	function getFilterValues() {
 		let filters = {};
-		$container.find('.rsd-filters select').each(function() {
 			let $filter = $(this);
 			let identifier = $filter.data('filter');
 			let value = $filter.val();
+		$container.find('.rsd-filters select').each(function () {
 			if (value != '') {
 				filters[identifier] = [value];
 			}
@@ -685,10 +684,10 @@ jQuery(function($) {
 	// Search field - attach search event and get new results from API.
 	// (executing with a slight delay after entry changes, so that the search term is not sent with every character)
 	var delayTimer;
-	$container.find('.rsd-search-input').on('input', function() {
+	$container.find('.rsd-search-input').on('input', function () {
 		clearTimeout(delayTimer);
 		var searchTerm = $(this).val().toLowerCase();
-		delayTimer = setTimeout(function() {
+		delayTimer = setTimeout(function () {
 			console.log('🎹 searchTerm: ', searchTerm);
 			loadFilters();
 			loadItems(searchTerm);
@@ -701,7 +700,7 @@ jQuery(function($) {
 	});
 
 	// Attach set filters event and get new results from API.
-	$container.find('.rsd-filters').on('change', 'select', function() {
+	$container.find('.rsd-filters').on('change', 'select', function () {
 		setCurrentFilters($(this).data('filter'), $(this).val());
 		loadFilters();
 		loadItems();
@@ -740,7 +739,7 @@ jQuery(function($) {
 	}
 
 	// Attach change event to sort by select.
-	$container.find('.rsd-sortby-input').on('change', function() {
+	$container.find('.rsd-sortby-input').on('change', function () {
 		loadItems();
 	});
 
@@ -798,7 +797,7 @@ jQuery(function($) {
 		}
 	}
 
-	$container.find('.rsd-back-to-top a').on('click', function() {
+	$container.find('.rsd-back-to-top a').on('click', function () {
 		$('html, body').animate({ scrollTop: 0 }, 400);
 		return false;
 	});
@@ -815,8 +814,8 @@ jQuery(function($) {
 
 	// Update filters.
 	function displayUpdateFilterValues(filters) {
-		$.each(filters, function(identifier, filter) {
 			let $filter = $container.find(`.rsd-filters select[data-filter="${identifier}"]`);
+		$.each(filters, function (identifier, filter) {
 			// Get first placeholder item.
 			let $placeholder = $filter.find('.placeholder');
 			// Clear the filter.
@@ -824,9 +823,9 @@ jQuery(function($) {
 			// Add the placeholder item back and add the new filter values.
 			$filter.append($placeholder);
 			// Add the new filter values.
-			filter.getItems().forEach(function(item) {
 				let value = item.name;
 				let label = filter.getLabel(value);
+			filter.getItems().forEach(function (item) {
 				let selected = '';
 				if (currentFilters[identifier] && currentFilters[identifier].includes(value)) {
 					selected = ' selected';
@@ -837,13 +836,21 @@ jQuery(function($) {
 	}
 
 	// Display the results.
-	function displayResults(items = [], totalCount = null, appendItems = false) {
+	function displayResults(
+		displayItems = [],
+		totalCount = null,
+		appendItems = false
+	) {
 		// Get the results container.
 		let $itemsContainer = $container.find('.rsd-results-items');
 
 		// Empty results container if no items are provided.
-		if (!items || !Array.isArray(items) || items.length === 0) {
 			$container.find('.rsd-results-items').empty();
+		if (
+			!displayItems ||
+			!Array.isArray(displayItems) ||
+			displayItems.length === 0
+		) {
 			displaySetResultsTotalCount(0);
 			return false;
 		}
@@ -856,7 +863,7 @@ jQuery(function($) {
 			$itemsContainer.empty();
 		}
 
-		$.each(items, function(index, item) {
+		$.each(displayItems, function (index, item) {
 			let title, description, props;
 			if ('projects' === section) {
 				title = item.title;

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -30,7 +30,7 @@ jQuery(function ($) {
 			in_progress: 'In progress',
 			finished: 'Finished',
 			unknown: 'Unknown',
-		}
+		},
 	};
 
 	// Get container element and section.
@@ -315,7 +315,7 @@ jQuery(function ($) {
 					args: { ...defaultArgs, labels: { ...defaultFilterLabels.project_status } },
 					filter_as_param: 'status_filter',
 					path: '/rpc/org_project_status_filter?order=project_status',
-					params: { ...defaultParams }
+					params: { ...defaultParams },
 				},
 				keyword: {
 					title: 'Keywords',
@@ -323,7 +323,7 @@ jQuery(function ($) {
 					args: { ...defaultArgs },
 					filter_as_param: 'keyword_filter',
 					path: '/rpc/org_project_keywords_filter?order=keyword',
-					params: { ...defaultParams }
+					params: { ...defaultParams },
 				},
 				domain: {
 					title: 'Research domains',
@@ -331,7 +331,7 @@ jQuery(function ($) {
 					args: { ...defaultArgs, labeled_only: true, labels: { ...defaultFilterLabels.domain } },
 					filter_as_param: 'research_domain_filter',
 					path: '/rpc/org_project_domains_filter?order=domain',
-					params: { ...defaultParams }
+					params: { ...defaultParams },
 				},
 				organisation: {
 					title: 'Partners',
@@ -339,8 +339,8 @@ jQuery(function ($) {
 					args: { ...defaultArgs },
 					filter_as_param: 'organisation_filter',
 					path: '/rpc/org_project_participating_organisations_filter?order=organisation',
-					params: { ...defaultParams }
-				}
+					params: { ...defaultParams },
+				},
 			},
 			software: {
 				keyword: {
@@ -349,7 +349,7 @@ jQuery(function ($) {
 					args: { ...defaultArgs },
 					filter_as_param: 'keyword_filter',
 					path: '/rpc/org_software_keywords_filter?order=keyword',
-					params: { ...defaultParams }
+					params: { ...defaultParams },
 				},
 				prog_language: {
 					title: 'Programming Languages',
@@ -357,7 +357,7 @@ jQuery(function ($) {
 					args: { ...defaultArgs },
 					filter_as_param: 'prog_lang_filter',
 					path: '/rpc/org_software_languages_filter?order=prog_language',
-					params: { ...defaultParams }
+					params: { ...defaultParams },
 				},
 				license: {
 					title: 'Licenses',
@@ -365,9 +365,9 @@ jQuery(function ($) {
 					args: { ...defaultArgs },
 					filter_as_param: 'license_filter',
 					path: '/rpc/org_software_licenses_filter?order=license',
-					params: { ...defaultParams }
-				}
-			}
+					params: { ...defaultParams },
+				},
+			},
 		};
 
 		// Build filters object for the current section, narrowed down by filter values.

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -105,9 +105,9 @@ jQuery(function ($) {
 					}
 				});
 				return filterItems;
-			} else {
-				return this.items;
 			}
+
+			return this.items;
 		}
 
 		setItems(data) {
@@ -186,9 +186,9 @@ jQuery(function ($) {
 		const nullsLast = ['mention_cnt', 'contributor_cnt', 'impact_cnt', 'output_cnt', 'date_start', 'date_end'];
 		if (nullsLast.includes(orderBy)) {
 			return `${orderBy.toLowerCase()}.${order.toLowerCase()}.nullslast`;
-		} else {
-			return `${orderBy.toLowerCase()}.${order.toLowerCase()}`;
 		}
+
+		return `${orderBy.toLowerCase()}.${order.toLowerCase()}`;
 	}
 
 
@@ -501,9 +501,9 @@ jQuery(function ($) {
 	function getItemImgUrl(item) {
 		if (item.image_id) {
 			return `https://research-software-directory.org/image/rpc/get_image?uid=${item.image_id}`;
-		} else {
-			return 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'; // Transparent 1x1 GIF
 		}
+
+		return 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'; // Transparent 1x1 GIF
 	}
 
 	function getItemImageContain(item) {
@@ -621,9 +621,9 @@ jQuery(function ($) {
 		const sortDesc = ['mention_cnt', 'contributor_cnt', 'impact_cnt', 'output_cnt', 'updated_at', 'date_end'];
 		if (orderBy && sortDesc.includes(orderBy)) {
 			return 'desc';
-		} else {
-			return 'asc';
 		}
+
+		return 'asc';
 	}
 
 	function getFilterValues() {

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -97,8 +97,8 @@ jQuery(function ($) {
 
 		getItems( labeledOnly = false ) {
 			if ( labeledOnly || this.args.labeled_only ) {
-				let items = [];
-				let labels = this.getLabels();
+				const items = [];
+				const labels = this.getLabels();
 				$.each(this.items, function (index, item) {
 					if (labels[item.name]) {
 						items.push(item);
@@ -117,15 +117,15 @@ jQuery(function ($) {
 			if (data && Array.isArray(data) && data.length !== 0) {
 				// Convert data to items.
 				this.items = data.map(item => {
-					let label = item[this.getIdentifier()];
-					let count = item[this.getIdentifier() + '_cnt'] || 0;
+					const label = item[this.getIdentifier()];
+					const count = item[this.getIdentifier() + '_cnt'] || 0;
 					return { name: label, count: count };
 				});
 			}
 		}
 
 		getPlaceholder() {
-			let defaultPlaceholder = 'Filter by ' + this.getTitle().toLowerCase(); // TODO: i18n
+			const defaultPlaceholder = 'Filter by ' + this.getTitle().toLowerCase(); // TODO: i18n
 			return this.args.placeholder || defaultPlaceholder;
 		}
 
@@ -183,7 +183,7 @@ jQuery(function ($) {
 
 	// Get the API order string.
 	function apiGetOrder(orderBy, order) {
-		let nullsLast = ['mention_cnt', 'contributor_cnt', 'impact_cnt', 'output_cnt', 'date_start', 'date_end'];
+		const nullsLast = ['mention_cnt', 'contributor_cnt', 'impact_cnt', 'output_cnt', 'date_start', 'date_end'];
 		if (nullsLast.includes(orderBy)) {
 			return `${orderBy.toLowerCase()}.${order.toLowerCase()}.nullslast`;
 		} else {
@@ -212,7 +212,7 @@ jQuery(function ($) {
 
 		// Build the API URL based on section.
 		let path = '';
-		let params = {
+		const params = {
 			organisation_id: organisationId,
 			status: 'eq.approved',
 			is_published: 'eq.true',
@@ -268,8 +268,8 @@ jQuery(function ($) {
 
 		// Get the data from the API.
 		return new Promise((resolve, reject) => {
-			let url = apiGetUrl(path, params);
-			let req = $.ajax({
+			const url = apiGetUrl(path, params);
+			const req = $.ajax({
 				type: 'GET',
 				url: url,
 				headers: { 'Prefer': 'count=exact' },
@@ -297,9 +297,9 @@ jQuery(function ($) {
 
 	// Get the filters from the API.
 	async function fetchFilters() {
-		let filters = {};
-		let defaultArgs = {};
-		let defaultParams = {
+		const filters = {};
+		const defaultArgs = {};
+		const defaultParams = {
 			organisation_id: organisationId,
 		};
 
@@ -307,7 +307,7 @@ jQuery(function ($) {
 			defaultParams.search_filter = getSearchTerm();
 		}
 
-		let filtersDefault = {
+		const filtersDefault = {
 			'projects': {
 				'project_status': {
 					title: 'Project status',
@@ -371,9 +371,9 @@ jQuery(function ($) {
 		}
 
 		// Build filters object for the current section, narrowed down by filter values.
-		let filterReqs = filtersDefault[section] || {};
-		let filterValues = getFilterValues();
-		let requests = [];
+		const filterReqs = filtersDefault[section] || {};
+		const filterValues = getFilterValues();
+		const requests = [];
 
 		// Add any filter values to the filter requests.
 		Object.keys(filterReqs).forEach(filter => {
@@ -383,7 +383,7 @@ jQuery(function ($) {
 					return;
 				}
 
-				let param = filterReqs[valueId].filter_as_param || false;
+				const param = filterReqs[valueId].filter_as_param || false;
 				if (param) {
 					if (valueId === 'project_status') {
 						filterReqs[filter].params[param] = filterValues[valueId][0] || '';
@@ -396,7 +396,7 @@ jQuery(function ($) {
 
 		// Get filter data from the API for each filter.
 		Object.entries(filterReqs).forEach(([filter, data]) => {
-			let promise = new Promise((resolve, reject) => {
+			const promise = new Promise((resolve, reject) => {
 				$.ajax({
 					type: 'POST',
 					url: apiGetUrl(data.path),
@@ -430,7 +430,7 @@ jQuery(function ($) {
 	async function loadItems() {
 		try {
 			// Fetch the items from the API.
-			let offset = 0;
+			const offset = 0;
 			items = await fetchItems(getSearchTerm(), getFilterValues(), getOrderBy(), getOrder(), offset);
 			currentOffset = offset + items.length;
 
@@ -451,13 +451,13 @@ jQuery(function ($) {
 
 		try {
 			// Fetch more items from the API.
-			let offset = currentOffset;
-			let newItems = await fetchItems(getSearchTerm(), getFilterValues(), getOrderBy(), getOrder(), offset);
+			const offset = currentOffset;
+			const newItems = await fetchItems(getSearchTerm(), getFilterValues(), getOrderBy(), getOrder(), offset);
 			items = items.concat(newItems);
 			currentOffset = offset + newItems.length;
 
 			// Append the results.
-			let appendItems = true;
+			const appendItems = true;
 			displayResults(newItems, itemsTotal, appendItems);
 		} catch (error) {
 			console.error('🎹 Error fetching more items: ', error);
@@ -556,12 +556,12 @@ jQuery(function ($) {
 	}
 
 	function getItemsFromDOM() {
-		let items = [];
-		let validProps = ['contributor_cnt', 'mention_cnt', 'impact_cnt', 'output_cnt'];
+		const items = [];
+		const validProps = ['contributor_cnt', 'mention_cnt', 'impact_cnt', 'output_cnt'];
 
 		$container.find('.rsd-results-item').each(function () {
-			let $item = $(this);
-			let item = {
+			const $item = $(this);
+			const item = {
 				id: $item.data('id'),
 				title: $item.find('h3').text(),
 				description: $item.find('.card-section p').text(),
@@ -569,8 +569,8 @@ jQuery(function ($) {
 				labels: [],
 			};
 			$item.find('.rsd-results-item-props li').each(function () {
-				let prop = $(this).attr('class').replace('rsd-results-item-prop-', '').trim() + '_cnt';
-				let value = parseInt($(this).find('.value').text());
+				const prop = $(this).attr('class').replace('rsd-results-item-prop-', '').trim() + '_cnt';
+				const value = parseInt($(this).find('.value').text());
 				if (validProps.includes(prop)) {
 					item[prop] = value;
 				}
@@ -582,7 +582,7 @@ jQuery(function ($) {
 	}
 
 	function getItemsTotalFromDOM() {
-		let count = $container.find('.rsd-results-count').data('items-total');
+		const count = $container.find('.rsd-results-count').data('items-total');
 		return parseInt(count);
 	}
 
@@ -613,12 +613,12 @@ jQuery(function ($) {
 	}
 
 	function getOrderBy() {
-		let orderBy = $container.find('.rsd-sortby-input').val().toLowerCase().trim();
+		const orderBy = $container.find('.rsd-sortby-input').val().toLowerCase().trim();
 		return orderBy || false;
 	}
 
 	function getOrder(orderBy = false) {
-		let sortDesc = ['mention_cnt', 'contributor_cnt', 'impact_cnt', 'output_cnt', 'updated_at', 'date_end'];
+		const sortDesc = ['mention_cnt', 'contributor_cnt', 'impact_cnt', 'output_cnt', 'updated_at', 'date_end'];
 		if (orderBy && sortDesc.includes(orderBy)) {
 			return 'desc';
 		} else {
@@ -627,11 +627,11 @@ jQuery(function ($) {
 	}
 
 	function getFilterValues() {
-		let filters = {};
+		const filters = {};
 		$container.find('.rsd-filters select').each(function () {
-			let $filter = $(this);
-			let identifier = $filter.data('filter');
-			let value = $filter.val();
+			const $filter = $(this);
+			const identifier = $filter.data('filter');
+			const value = $filter.val();
 			if (value != '') {
 				filters[identifier] = [value];
 			}
@@ -661,8 +661,8 @@ jQuery(function ($) {
 	}
 
 	function toggleFiltersSidebar() {
-		let $sidebar = $container.find('.rsd-filter-sidebar');
-		let $button = $container.find('.rsd-filter-button button');
+		const $sidebar = $container.find('.rsd-filter-sidebar');
+		const $button = $container.find('.rsd-filter-button button');
 		$sidebar.toggle();
 
 		if ($sidebar.is(':visible')) {
@@ -726,7 +726,7 @@ jQuery(function ($) {
 
 	// Enhance filters sidebar.
 	function enhanceFiltersSidebar(filters) {
-		let $sidebar = $container.find('.rsd-filter-sidebar');
+		const $sidebar = $container.find('.rsd-filter-sidebar');
 
 		// Add close button to filters sidebar.
 		$sidebar.prepend(`
@@ -749,7 +749,7 @@ jQuery(function ($) {
 			return false;
 		}
 
-		let targetElement = $('.rsd-results-show-more')[0];
+		const targetElement = $('.rsd-results-show-more')[0];
 
 		if (scrollObserver) {
 			// Continue observing the target element.
@@ -787,8 +787,8 @@ jQuery(function ($) {
 	enhanceBackToTopButton();
 
 	function enhanceBackToTopButton() {
-		let offset = $container.offset().top || 100;
-		let $button = $container.find('.rsd-back-to-top');
+		const offset = $container.offset().top || 100;
+		const $button = $container.find('.rsd-back-to-top');
 
 		if ($(window).scrollTop() > offset) {
 			$button.addClass('visible');
@@ -815,17 +815,17 @@ jQuery(function ($) {
 	// Update filters.
 	function displayUpdateFilterValues(filters) {
 		$.each(filters, function (identifier, filter) {
-			let $filter = $container.find(`.rsd-filters select[data-filter="${identifier}"]`);
+			const $filter = $container.find(`.rsd-filters select[data-filter="${identifier}"]`);
 			// Get first placeholder item.
-			let $placeholder = $filter.find('.placeholder');
+			const $placeholder = $filter.find('.placeholder');
 			// Clear the filter.
 			$filter.empty();
 			// Add the placeholder item back and add the new filter values.
 			$filter.append($placeholder);
 			// Add the new filter values.
 			filter.getItems().forEach(function (item) {
-				let value = item.name;
-				let label = filter.getLabel(value);
+				const value = item.name;
+				const label = filter.getLabel(value);
 				let selected = '';
 				if (currentFilters[identifier] && currentFilters[identifier].includes(value)) {
 					selected = ' selected';
@@ -842,7 +842,7 @@ jQuery(function ($) {
 		appendItems = false
 	) {
 		// Get the results container.
-		let $itemsContainer = $container.find('.rsd-results-items');
+		const $itemsContainer = $container.find('.rsd-results-items');
 
 		// Empty results container if no items are provided.
 		if (

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -226,14 +226,14 @@ jQuery(function ($) {
 		}
 
 		if (section === 'projects') {
-			if (searchTerm != '') {
+			if (searchTerm !== '') {
 				path = '/rpc/projects_by_organisation_search';
 				params.search = searchTerm;
 			} else {
 				path = '/rpc/projects_by_organisation';
 			}
 		} else if (section === 'software') {
-			if (searchTerm != '') {
+			if (searchTerm !== '') {
 				path = '/rpc/software_by_organisation_search';
 				params.search = searchTerm;
 			} else {
@@ -634,7 +634,7 @@ jQuery(function ($) {
 			const $filter = $(this);
 			const identifier = $filter.data('filter');
 			const value = $filter.val();
-			if (value != '') {
+			if (value && value !== '') {
 				filters[identifier] = [value];
 			}
 		});

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -272,14 +272,14 @@ jQuery(function ($) {
 				url: url,
 				headers: { 'Prefer': 'count=exact' },
 				success: function (response) {
-					let resultItems = response;
+					const resultItems = response;
 					console.log('🎹 result items: ', resultItems);
 
 					// Get the total count of results from `content-range` response header.
 					let totalResults = false;
-					let contentRange = req.getResponseHeader('content-range');
+					const contentRange = req.getResponseHeader('content-range');
 					if (contentRange) {
-						let total = contentRange.split('/');
+						const total = contentRange.split('/');
 						totalResults = total[1];
 						itemsTotal = parseInt(totalResults);
 					}
@@ -684,7 +684,7 @@ jQuery(function ($) {
 	let delayTimer;
 	$container.find('.rsd-search-input').on('input', function () {
 		clearTimeout(delayTimer);
-		let searchTerm = $(this).val().toLowerCase();
+		const searchTerm = $(this).val().toLowerCase();
 		delayTimer = setTimeout(function () {
 			console.log('🎹 searchTerm: ', searchTerm);
 			loadFilters();
@@ -848,7 +848,7 @@ jQuery(function ($) {
 			!Array.isArray(displayItems) ||
 			displayItems.length === 0
 		) {
-			$container.find('.rsd-results-items').empty();
+			$itemsContainer.empty();
 			displaySetResultsTotalCount(0);
 			return false;
 		}

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -119,7 +119,7 @@ jQuery(function ($) {
 				this.items = data.map(item => {
 					const label = item[this.getIdentifier()];
 					const count = item[this.getIdentifier() + '_cnt'] || 0;
-					return { name: label, count };
+					return { name: label, count: count };
 				});
 			}
 		}
@@ -217,7 +217,7 @@ jQuery(function ($) {
 			status: 'eq.approved',
 			is_published: 'eq.true',
 			limit: defaultLimit,
-			offset,
+			offset: offset,
 		};
 
 		if (orderBy) {
@@ -266,9 +266,10 @@ jQuery(function ($) {
 
 		// Get the data from the API.
 		return new Promise((resolve, reject) => {
+			const url = apiGetUrl(path, params);
 			const req = $.ajax({
 				type: 'GET',
-				url: apiGetUrl(path, params),
+				url: url,
 				headers: { 'Prefer': 'count=exact' },
 				// eslint-disable-next-line object-shorthand
 				success: function (response) {

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -366,7 +366,7 @@ jQuery(function ($) {
 					params: { ...defaultParams }
 				}
 			}
-		}
+		};
 
 		// Build filters object for the current section, narrowed down by filter values.
 		const filterReqs = filtersDefault[section] || {};
@@ -869,14 +869,14 @@ jQuery(function ($) {
 				props = {
 					'Impact': getItemImpactCount(item),
 					'Output': getItemOutputCount(item),
-				}
+				};
 			} else {
 				title = item.brand_name;
 				description = item.short_statement;
 				props = {
 					'Contributors': getItemContributorsCount(item),
 					'Mentions': getItemMentionsCount(item),
-				}
+				};
 			}
 
 			let imageContainAttr = '';

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -95,13 +95,13 @@ jQuery(function ($) {
 			return prefix + this.identifier;
 		}
 
+		getItems( labeledOnly = false ) {
+			if ( labeledOnly || this.args.labeled_only ) {
 				let items = [];
 				let labels = this.getLabels();
 				$.each(this.items, function (index, item) {
 					if (labels[item.name]) {
 						items.push(item);
-		getItems( labeledOnly = false ) {
-			if ( labeledOnly || this.args.labeled_only ) {
 					}
 				});
 				return items;
@@ -628,10 +628,10 @@ jQuery(function ($) {
 
 	function getFilterValues() {
 		let filters = {};
+		$container.find('.rsd-filters select').each(function () {
 			let $filter = $(this);
 			let identifier = $filter.data('filter');
 			let value = $filter.val();
-		$container.find('.rsd-filters select').each(function () {
 			if (value != '') {
 				filters[identifier] = [value];
 			}
@@ -814,8 +814,8 @@ jQuery(function ($) {
 
 	// Update filters.
 	function displayUpdateFilterValues(filters) {
-			let $filter = $container.find(`.rsd-filters select[data-filter="${identifier}"]`);
 		$.each(filters, function (identifier, filter) {
+			let $filter = $container.find(`.rsd-filters select[data-filter="${identifier}"]`);
 			// Get first placeholder item.
 			let $placeholder = $filter.find('.placeholder');
 			// Clear the filter.
@@ -823,9 +823,9 @@ jQuery(function ($) {
 			// Add the placeholder item back and add the new filter values.
 			$filter.append($placeholder);
 			// Add the new filter values.
+			filter.getItems().forEach(function (item) {
 				let value = item.name;
 				let label = filter.getLabel(value);
-			filter.getItems().forEach(function (item) {
 				let selected = '';
 				if (currentFilters[identifier] && currentFilters[identifier].includes(value)) {
 					selected = ' selected';
@@ -845,12 +845,12 @@ jQuery(function ($) {
 		let $itemsContainer = $container.find('.rsd-results-items');
 
 		// Empty results container if no items are provided.
-			$container.find('.rsd-results-items').empty();
 		if (
 			!displayItems ||
 			!Array.isArray(displayItems) ||
 			displayItems.length === 0
 		) {
+			$container.find('.rsd-results-items').empty();
 			displaySetResultsTotalCount(0);
 			return false;
 		}

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -231,7 +231,7 @@ jQuery(function ($) {
 			} else {
 				path = '/rpc/projects_by_organisation';
 			}
-		} else {
+		} else if (section === 'software') {
 			if (searchTerm != '') {
 				path = '/rpc/software_by_organisation_search';
 				params.search = searchTerm;
@@ -253,12 +253,10 @@ jQuery(function ($) {
 		Object.keys(filterParamMap).forEach(filterKey => {
 			const paramKey = filterParamMap[filterKey];
 			const filterValue = filters[filterKey];
-			if (paramKey === 'project_status') {
-				if (filterValue && filterValue.length > 0) {
+			if (filterValue && filterValue.length > 0) {
+				if (paramKey === 'project_status') {
 					params[paramKey] = `eq.${filterValue.flat().map(value => value.toLowerCase())}`;
-				}
-			} else {
-				if (filterValue && filterValue.length > 0) {
+				} else {
 					params[paramKey] = 'cs.{' + filterValue.map(value => `"${value}"`).join(',') + '}';
 				}
 			}

--- a/src/js/rsd-wordpress.js
+++ b/src/js/rsd-wordpress.js
@@ -125,7 +125,8 @@ jQuery(function ($) {
 		}
 
 		getPlaceholder() {
-			const defaultPlaceholder = 'Filter by ' + this.getTitle().toLowerCase(); // TODO: i18n
+			const defaultPlaceholder =
+				'Filter by ' + this.getTitle().toLowerCase(); // TODO: i18n
 			return this.args.placeholder || defaultPlaceholder;
 		}
 
@@ -175,15 +176,28 @@ jQuery(function ($) {
 
 	// Get the API URL.
 	function apiGetUrl(path, params = {}) {
-		if (params && typeof params === 'object' && Object.keys(params).length !== 0) {
+		if (
+			params &&
+			typeof params === 'object' &&
+			Object.keys( params ).length !== 0
+		) {
 			path = path + '?' + $.param(params);
 		}
-		return apiEndpoint + '/' + apiVersion + '/' + path.replace(/^\/+/, '');
+		return (
+			apiEndpoint + '/' + apiVersion + '/' + path.replace( /^\/+/, '' )
+		);
 	}
 
 	// Get the API order string.
 	function apiGetOrder(orderBy, order) {
-		const nullsLast = ['mention_cnt', 'contributor_cnt', 'impact_cnt', 'output_cnt', 'date_start', 'date_end'];
+		const nullsLast = [
+			'mention_cnt',
+			'contributor_cnt',
+			'impact_cnt',
+			'output_cnt',
+			'date_start',
+			'date_end',
+		];
 		if (nullsLast.includes(orderBy)) {
 			return `${orderBy.toLowerCase()}.${order.toLowerCase()}.nullslast`;
 		}
@@ -197,16 +211,27 @@ jQuery(function ($) {
 	*/
 
 	// Get the result items from the API.
-	async function fetchItems(searchTerm = false, filters = false, orderBy = false, order = false, offset = 0) {
+	async function fetchItems(
+		searchTerm = false,
+		filters = false,
+		orderBy = false,
+		order = false,
+		offset = 0
+	) {
 		// Get the search term and filter values.
-		searchTerm = searchTerm ? searchTerm.toLowerCase().trim() : getSearchTerm();
+		searchTerm = searchTerm
+			? searchTerm.toLowerCase().trim()
+			: getSearchTerm();
 		filters = filters ? filters : getFilterValues();
 		orderBy = orderBy ? orderBy : getOrderBy();
 		order = order ? order : getOrder(orderBy);
 		offset = offset ? offset : 0;
 
 		// Hide the 'Clear filters' button if no search term or filters are set.
-		if (searchTerm || (filters && Object.keys(filters).length !== 0)) {
+		if (
+			searchTerm ||
+			( filters && Object.keys( filters ).length !== 0 )
+		) {
 			showClearFiltersButton();
 		}
 
@@ -256,9 +281,16 @@ jQuery(function ($) {
 			const filterValue = filters[filterKey];
 			if (filterValue && filterValue.length > 0) {
 				if (paramKey === 'project_status') {
-					params[paramKey] = `eq.${filterValue.flat().map(value => value.toLowerCase())}`;
+					params[ paramKey ] = `eq.${ filterValue
+						.flat()
+						.map( ( value ) => value.toLowerCase() ) }`;
 				} else {
-					params[paramKey] = 'cs.{' + filterValue.map(value => `"${value}"`).join(',') + '}';
+					params[ paramKey ] =
+						'cs.{' +
+						filterValue
+							.map( ( value ) => `"${ value }"` )
+							.join( ',' ) +
+						'}';
 				}
 			}
 		});
@@ -278,7 +310,8 @@ jQuery(function ($) {
 
 					// Get the total count of results from `content-range` response header.
 					let totalResults = false;
-					const contentRange = req.getResponseHeader('content-range');
+					const contentRange =
+						req.getResponseHeader( 'content-range' );
 					if (contentRange) {
 						const total = contentRange.split('/');
 						totalResults = total[1];
@@ -312,7 +345,10 @@ jQuery(function ($) {
 				project_status: {
 					title: 'Project status',
 					identifier: 'project_status',
-					args: { ...defaultArgs, labels: { ...defaultFilterLabels.project_status } },
+					args: {
+						...defaultArgs,
+						labels: { ...defaultFilterLabels.project_status },
+					},
 					filter_as_param: 'status_filter',
 					path: '/rpc/org_project_status_filter?order=project_status',
 					params: { ...defaultParams },
@@ -328,7 +364,11 @@ jQuery(function ($) {
 				domain: {
 					title: 'Research domains',
 					identifier: 'domain',
-					args: { ...defaultArgs, labeled_only: true, labels: { ...defaultFilterLabels.domain } },
+					args: {
+						...defaultArgs,
+						labeled_only: true,
+						labels: { ...defaultFilterLabels.domain },
+					},
 					filter_as_param: 'research_domain_filter',
 					path: '/rpc/org_project_domains_filter?order=domain',
 					params: { ...defaultParams },
@@ -378,7 +418,10 @@ jQuery(function ($) {
 		// Add any filter values to the filter requests.
 		Object.keys(filterReqs).forEach(filter => {
 			Object.keys(filterValues).forEach(valueId => {
-				if (valueId === 'project_status' && filter === 'project_status') {
+				if (
+					valueId === 'project_status' &&
+					filter === 'project_status'
+				) {
 					// Skip the project_status filter if it's set to project_status.
 					return;
 				}
@@ -386,9 +429,11 @@ jQuery(function ($) {
 				const param = filterReqs[valueId].filter_as_param || false;
 				if (param) {
 					if (valueId === 'project_status') {
-						filterReqs[filter].params[param] = filterValues[valueId][0] || '';
+						filterReqs[ filter ].params[ param ] =
+							filterValues[ valueId ][ 0 ] || '';
 					} else {
-						filterReqs[filter].params[param] = filterValues[valueId];
+						filterReqs[ filter ].params[ param ] =
+							filterValues[ valueId ];
 					}
 				}
 			});
@@ -405,7 +450,12 @@ jQuery(function ($) {
 					contentType: 'application/json',
 					// eslint-disable-next-line object-shorthand
 					success: function (response) {
-						filters[filter] = new Filter(data.title, data.identifier, response, data.args);
+						filters[ filter ] = new Filter(
+							data.title,
+							data.identifier,
+							response,
+							data.args
+						);
 						resolve();
 					},
 					// eslint-disable-next-line object-shorthand
@@ -433,7 +483,13 @@ jQuery(function ($) {
 		try {
 			// Fetch the items from the API.
 			const offset = 0;
-			items = await fetchItems(getSearchTerm(), getFilterValues(), getOrderBy(), getOrder(), offset);
+			items = await fetchItems(
+				getSearchTerm(),
+				getFilterValues(),
+				getOrderBy(),
+				getOrder(),
+				offset
+			);
 			currentOffset = offset + items.length;
 
 			// Display the results.
@@ -454,7 +510,13 @@ jQuery(function ($) {
 		try {
 			// Fetch more items from the API.
 			const offset = currentOffset;
-			const newItems = await fetchItems(getSearchTerm(), getFilterValues(), getOrderBy(), getOrder(), offset);
+			const newItems = await fetchItems(
+				getSearchTerm(),
+				getFilterValues(),
+				getOrderBy(),
+				getOrder(),
+				offset
+			);
 			items = items.concat(newItems);
 			currentOffset = offset + newItems.length;
 
@@ -559,7 +621,12 @@ jQuery(function ($) {
 
 	function getItemsFromDOM() {
 		const domItems = [];
-		const validProps = ['contributor_cnt', 'mention_cnt', 'impact_cnt', 'output_cnt'];
+		const validProps = [
+			'contributor_cnt',
+			'mention_cnt',
+			'impact_cnt',
+			'output_cnt',
+		];
 
 		$container.find('.rsd-results-item').each(function () {
 			const $item = $(this);
@@ -571,7 +638,11 @@ jQuery(function ($) {
 				labels: [],
 			};
 			$item.find('.rsd-results-item-props li').each(function () {
-				const prop = $(this).attr('class').replace('rsd-results-item-prop-', '').trim() + '_cnt';
+				const prop =
+					$( this )
+						.attr( 'class' )
+						.replace( 'rsd-results-item-prop-', '' )
+						.trim() + '_cnt';
 				const value = parseInt($(this).find('.value').text());
 				if (validProps.includes(prop)) {
 					item[prop] = value;
@@ -584,7 +655,9 @@ jQuery(function ($) {
 	}
 
 	function getItemsTotalFromDOM() {
-		const count = $container.find('.rsd-results-count').data('items-total');
+		const count = $container
+			.find( '.rsd-results-count' )
+			.data( 'items-total' );
 		return parseInt(count);
 	}
 
@@ -611,16 +684,31 @@ jQuery(function ($) {
 	*/
 
 	function getSearchTerm() {
-		return $container.find('.rsd-search-input').val().toLowerCase().trim();
+		return $container
+			.find( '.rsd-search-input' )
+			.val()
+			.toLowerCase()
+			.trim();
 	}
 
 	function getOrderBy() {
-		const orderBy = $container.find('.rsd-sortby-input').val().toLowerCase().trim();
+		const orderBy = $container
+			.find( '.rsd-sortby-input' )
+			.val()
+			.toLowerCase()
+			.trim();
 		return orderBy || false;
 	}
 
 	function getOrder(orderBy = false) {
-		const sortDesc = ['mention_cnt', 'contributor_cnt', 'impact_cnt', 'output_cnt', 'updated_at', 'date_end'];
+		const sortDesc = [
+			'mention_cnt',
+			'contributor_cnt',
+			'impact_cnt',
+			'output_cnt',
+			'updated_at',
+			'date_end',
+		];
 		if (orderBy && sortDesc.includes(orderBy)) {
 			return 'desc';
 		}
@@ -724,7 +812,9 @@ jQuery(function ($) {
 	}
 
 	// Attach click event to filters toggle button.
-	$container.find('.rsd-filter-button button').on('click', toggleFiltersSidebar);
+	$container
+		.find( '.rsd-filter-button button' )
+		.on( 'click', toggleFiltersSidebar );
 
 	// Enhance filters sidebar.
 	function enhanceFiltersSidebar() {
@@ -760,16 +850,17 @@ jQuery(function ($) {
 			}
 		} else {
 			// Start observing the target element.
-			scrollObserver = new IntersectionObserver(async (entries, observer) => {
-				if (entries[0].isIntersecting) {
-					if (hasMoreItems()) {
-						loadMoreItems();
-					} else {
-						observer.unobserve(entries[0].target);
+			scrollObserver = new IntersectionObserver(
+				async ( entries, observer ) => {
+					if ( entries[ 0 ].isIntersecting ) {
+						if ( hasMoreItems() ) {
+							loadMoreItems();
+						} else {
+							observer.unobserve( entries[ 0 ].target );
+						}
 					}
-
 				}
-			});
+			);
 
 			scrollObserver.observe(targetElement);
 		}
@@ -782,7 +873,9 @@ jQuery(function ($) {
 	}
 
 	// Attach click event to 'Show more' button.
-	$container.find('.rsd-results-show-more .button').on('click', loadMoreItems);
+	$container
+		.find( '.rsd-results-show-more .button' )
+		.on( 'click', loadMoreItems );
 
 	// Attach back to top button scroll handler and execute on page load.
 	$(window).on('scroll', enhanceBackToTopButton);
@@ -811,13 +904,17 @@ jQuery(function ($) {
 
 	// Update the result count.
 	function displaySetResultsTotalCount(count) {
-		$container.find('.rsd-results-count').text(`${count} items found`);
+		$container
+			.find( '.rsd-results-count' )
+			.text( `${ count } items found` );
 	}
 
 	// Update filters.
 	function displayUpdateFilterValues(filters) {
 		$.each(filters, function (identifier, filter) {
-			const $filter = $container.find(`.rsd-filters select[data-filter="${identifier}"]`);
+			const $filter = $container.find(
+				`.rsd-filters select[data-filter="${ identifier }"]`
+			);
 			// Get first placeholder item.
 			const $placeholder = $filter.find('.placeholder');
 			// Clear the filter.
@@ -829,10 +926,15 @@ jQuery(function ($) {
 				const value = item.name;
 				const label = filter.getLabel(value);
 				let selected = '';
-				if (currentFilters[identifier] && currentFilters[identifier].includes(value)) {
+				if (
+					currentFilters[ identifier ] &&
+					currentFilters[ identifier ].includes( value )
+				) {
 					selected = ' selected';
 				}
-				$filter.append(`<option value="${value}"${selected}>${label}</option>`);
+				$filter.append(
+					`<option value="${ value }"${ selected }>${ label }</option>`
+				);
 			});
 		});
 	}

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,7 +8,7 @@
  */
 
 import { defineConfig } from 'vite';
-import postcss, { plugin } from 'postcss';
+import postcss from 'postcss';
 import browserslist from 'browserslist';
 import { browserslistToTargets } from 'lightningcss';
 import autoprefixer from 'autoprefixer';

--- a/vite.config.js
+++ b/vite.config.js
@@ -32,10 +32,7 @@ const baseConfig = {
 		},
 		css: {
 			postcss: {
-				plugins: [
-					postcss(),
-					autoprefixer(),
-				],
+				plugins: [postcss(), autoprefixer()],
 			},
 			transformer: 'lightningcss',
 			lightningcss: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,10 +2,9 @@
  * RSD WordPress - Vite configuration file
  * https://vitejs.dev/config/
  *
- * @package RSD_WP
+ * @module
  * @since 0.8.0
  * @license Apache-2.0
- * @link https://research-software-directory.org
  */
 
 import { defineConfig } from 'vite';


### PR DESCRIPTION
This pull request integrates [ESLint](https://eslint.org/) and [Prettier,](https://prettier.io/) using WordPress specific config packages and rules.

The `eslint-plugin-compat` package can be helpful with detecting incompatible code, eventually removing the need for Babel transpiling.

Notes:
- the ESLint package is configured to be compatible with version 8.x, because it seems that the VS Code ESLint extension is not yet compatible with ESLint 9.x.
- scripts for  `lint` and `lint:fix` are now available (for example `pnpm run lint:fix), which can be used to either check or write any problems that are found by ESLint from the command-line.

See also:
- https://developer.wordpress.org/block-editor/reference-guides/packages/packages-eslint-plugin/
- https://github.com/Automattic/wp-prettier