### PR TITLE
Add progress bar to Projects result items

### DIFF
--- a/includes/models/class-project-item.php
+++ b/includes/models/class-project-item.php
@@ -139,19 +139,33 @@ class Project_Item extends Item {
 	/**
 	 * Get the item start date.
 	 *
+	 * @param string $format The date format.
 	 * @return string
 	 */
-	public function get_date_start() {
-		return $this->date_start;
+	public function get_date_start( $format = 'Y-m-d' ) {
+		if ( empty( $this->date_start ) ) {
+			return '';
+		}
+
+		$timezone = get_option( 'timezone_string' );
+		$date     = new \DateTimeImmutable( $this->date_start, new \DateTimeZone( $timezone ) );
+		return $date->format( $format );
 	}
 
 	/**
 	 * Get the item end date.
 	 *
+	 * @param string $format The date format.
 	 * @return string
 	 */
-	public function get_date_end() {
-		return $this->date_end;
+	public function get_date_end( $format = 'Y-m-d' ) {
+		if ( empty( $this->date_end ) ) {
+			return '';
+		}
+
+		$timezone = get_option( 'timezone_string' );
+		$date     = new \DateTimeImmutable( $this->date_end, new \DateTimeZone( $timezone ) );
+		return $date->format( $format );
 	}
 
 	/**

--- a/includes/models/class-project-item.php
+++ b/includes/models/class-project-item.php
@@ -232,17 +232,27 @@ class Project_Item extends Item {
 	}
 
 	/**
-	 * Get the item progress.
+	 * Get the item progress percentage.
 	 *
 	 * @return string
 	 */
-	public function get_progress() {
-		$progress = '';
-
-		if ( ! empty( $this->date_start ) && ! empty( $this->date_end ) ) {
-			$progress = wp_date( 'Y', strtotime( $this->date_end ) ) - wp_date( 'Y', strtotime( $this->date_start ) );
+	public function get_progress_percentage() {
+		if ( empty( $this->date_start ) || empty( $this->date_end ) ) {
+			return 0;
 		}
 
-		return $progress;
+		$date_start = new \DateTimeImmutable( $this->date_start );
+		$date_end   = new \DateTimeImmutable( $this->date_end );
+		$now        = new \DateTimeImmutable();
+
+		if ( $now > $date_end ) {
+			return 100;
+		} elseif ( $now < $date_start ) {
+			return 0;
+		} else {
+			$total   = $date_start->diff( $date_end )->days;
+			$elapsed = $date_start->diff( $now )->days;
+			return round( ( $elapsed / $total ) * 100 );
+		}
 	}
 }

--- a/includes/public/class-display.php
+++ b/includes/public/class-display.php
@@ -386,11 +386,12 @@ class Display {
 		$title    = $item->get_title();
 		$item_url = sprintf( 'https://research-software-directory.org/projects/%s', $item->get_slug() );
 		// translators: Aria label for the logo of a project item.
-		$aria_label         = sprintf( __( "Logo for '%s'", 'rsd-wordpress' ), $title );
-		$image_url          = $item->get_image_url();
-		$image_contain_attr = ( $item->get_image_contain() ? ' class="contain"' : '' );
-		$use_wp_timezone    = true;
-		$last_updated_local = $item->get_last_updated( $use_wp_timezone );
+		$aria_label           = sprintf( __( "Logo for '%s'", 'rsd-wordpress' ), $title );
+		$image_url            = $item->get_image_url();
+		$image_contain_attr   = ( $item->get_image_contain() ? ' class="contain"' : '' );
+		$use_wp_timezone      = true;
+		$last_updated_local   = $item->get_last_updated( $use_wp_timezone );
+		$progress_date_format = 'M Y';
 
 		if ( empty( $image_url ) ) {
 			$image_url = self::get_default_image_url();
@@ -418,8 +419,12 @@ class Display {
 					<?php endif; ?>
 				</div>
 				<ul class="rsd-results-item-props">
-					<li class="rsd-results-item-prop-progress">
-						<span class="prop"><?php esc_html_e( 'progress:', 'rsd-wordpress' ); ?></span> <?php echo esc_html( $item->get_progress() ); ?>
+					<li class="rsd-results-item-prop-progress" data-progress-percentage="<?php echo esc_attr( $item->get_progress_percentage() ); ?>">
+						<span class="value date-start"><?php echo esc_html( $item->get_date_start( $progress_date_format ) ); ?></span> -
+						<span class="value date-end"><?php echo esc_html( $item->get_date_end( $progress_date_format ) ); ?></span>
+						<div class="progress-bar" role="progressbar" tabindex="0" aria-valuenow="<?php echo esc_attr( $item->get_progress_percentage() ); ?>" aria-valuemin="0" aria-valuemax="100">
+							<div class="progress-meter" style="width: <?php echo esc_attr( $item->get_progress_percentage() ); ?>%;"></div>
+						</div>
 					</li>
 					<li class="rsd-results-item-prop-impact">
 						<span aria-hidden="true" class="icon icon-impact" title="<?php esc_html_e( 'Impact', 'rsd-wordpress' ); ?>"></span>

--- a/src/css/rsd-wordpress.css
+++ b/src/css/rsd-wordpress.css
@@ -197,6 +197,7 @@ input[type="search"].rsd-search-input {
 	text-align: center;
 	background-color: transparent;
 	color: #666;
+	font-size: 0.8rem;
 }
 
 .rsd-results-item-props li:last-child {

--- a/src/css/rsd-wordpress.css
+++ b/src/css/rsd-wordpress.css
@@ -229,7 +229,17 @@ input[type="search"].rsd-search-input {
 }
 
 .rsd-results-item-props .rsd-results-item-prop-progress {
-	display: none;
+	display: block;
+	margin-bottom: 1rem;
+}
+
+.rsd-results-item-props .progress-bar {
+	height: 0.2rem;
+	background-color: #f9f9f9;
+}
+
+.rsd-results-item-props .progress-meter {
+	background-color: #cacaca;
 }
 
 .rsd-results-show-more {

--- a/src/js/components/item.js
+++ b/src/js/components/item.js
@@ -92,6 +92,44 @@ export default class Item {
 		return this.updated_at || '';
 	}
 
+	getDate(
+		dateStr,
+		format = { year: 'numeric', month: '2-digit', day: '2-digit' }
+	) {
+		if ( ! dateStr ) return '';
+
+		const date = new Date( dateStr );
+		const formatter = new Intl.DateTimeFormat( 'en-UK', format );
+		return formatter.format( date );
+	}
+
+	getDateStart(
+		format = { year: 'numeric', month: '2-digit', day: '2-digit' }
+	) {
+		return this.getDate( this.date_start, format );
+	}
+
+	getDateEnd(
+		format = { year: 'numeric', month: '2-digit', day: '2-digit' }
+	) {
+		return this.getDate( this.date_end, format );
+	}
+
+	getProgressPercentage() {
+		const dateStart = new Date( this.date_start );
+		const dateEnd = new Date( this.date_end );
+		const now = new Date();
+
+		if ( ! isNaN( dateStart.getTime() ) && ! isNaN( dateEnd.getTime() ) ) {
+			const total = ( dateEnd - dateStart ) / ( 1000 * 60 * 60 * 24 );
+			const elapsed = ( now - dateStart ) / ( 1000 * 60 * 60 * 24 );
+
+			return Math.round( ( elapsed / total ) * 100 );
+		}
+
+		return 0;
+	}
+
 	getLabels() {
 		let html = '<ul class="rsd-results-item-labels">';
 		$.each( this.keywords, function ( index, label ) {

--- a/src/js/components/item.js
+++ b/src/js/components/item.js
@@ -142,14 +142,32 @@ export default class Item {
 
 	getProps( props ) {
 		let html = '<ul class="rsd-results-item-props">';
+		const self = this;
+		const progressDateFormat = {
+			year: 'numeric',
+			month: 'short',
+		};
+
 		$.each( props, function ( prop, value ) {
-			html += `
-				<li class="rsd-results-item-prop-${ prop.toLowerCase() }">
-					<span aria-hidden="true" class="icon icon-${ prop.toLowerCase() }" title="${ prop }"></span>
-					<span class="value">${ value }</span>
-					<span class="prop">${ prop.toLowerCase() }</span>
-				</li>
-			`;
+			if ( 'Progress' === prop ) {
+				html += `
+					<li class="rsd-results-item-prop-progress" data-progress-percentage="${ value }">
+						<span class="value date-start">${ self.getDateStart( progressDateFormat ) }</span> -
+						<span class="value date-end">${ self.getDateEnd( progressDateFormat ) }</span>
+						<div class="progress-bar" role="progressbar" tabindex="0" aria-valuenow="${ value }" aria-valuemin="0" aria-valuemax="100">
+							<div class="progress-meter" style="width: ${ value }%;"></div>
+						</div>
+					</li>
+					`;
+			} else {
+				html += `
+					<li class="rsd-results-item-prop-${ prop.toLowerCase() }">
+						<span aria-hidden="true" class="icon icon-${ prop.toLowerCase() }" title="${ prop }"></span>
+						<span class="value">${ value }</span>
+						<span class="prop">${ prop.toLowerCase() }</span>
+					</li>
+					`;
+			}
 		} );
 		html += '</ul>';
 

--- a/src/js/display/ui.js
+++ b/src/js/display/ui.js
@@ -120,6 +120,7 @@ class UI {
 				title = item.title;
 				description = item.subtitle || '';
 				props = {
+					Progress: item.getProgressPercentage(),
 					Impact: item.getImpactCount(),
 					Output: item.getOutputCount(),
 				};


### PR DESCRIPTION
This pull request implements a progress bar for result items under the Projects section.

The implementation is both in PHP and JS, and the HTML output is aimed at the [Foundation Progress Bar](https://get.foundation/sites/docs/progress-bar.html) component.