### PR TITLE
Add default thumbnail image URL to plugin settings

### DIFF
--- a/includes/admin/class-settings-admin.php
+++ b/includes/admin/class-settings-admin.php
@@ -111,6 +111,21 @@ class Settings_Admin extends \RSD\Settings {
 			'rsd-wordpress',
 			'rsd_filters_section'
 		);
+
+		add_settings_section(
+			'rsd_images_section',
+			__( 'Images', 'rsd-wordpress' ),
+			array( __CLASS__, 'images_section_html' ),
+			'rsd-wordpress'
+		);
+
+		add_settings_field(
+			'img_url',
+			__( 'Default image URL', 'rsd-wordpress' ),
+			array( __CLASS__, 'default_img_url_html' ),
+			'rsd-wordpress',
+			'rsd_images_section'
+		);
 	}
 
 	/**
@@ -119,7 +134,16 @@ class Settings_Admin extends \RSD\Settings {
 	 * @return void
 	 */
 	public static function filters_section_html() {
-		echo '<p>' . esc_html__( 'Configure the filters to be shown for each section using the checkboxes below.', 'rsd-wordpress' ) . '</p>';
+		echo '<p>' . esc_html__( 'Configure the filters to be shown for each section using the checkboxes below.', 'rsd-wordpress' ) . '</p>' . "\n";
+	}
+
+	/**
+	 * Images section HTML callback.
+	 *
+	 * @return void
+	 */
+	public static function images_section_html() {
+		// Do nothing (yet).
 	}
 
 	/**
@@ -165,5 +189,26 @@ class Settings_Admin extends \RSD\Settings {
 	 */
 	public static function projects_default_filters_html() {
 		self::default_filters_html( 'projects' );
+	}
+
+	/**
+	 * Default image URL HTML callback.
+	 *
+	 * @return void
+	 */
+	public static function default_img_url_html() {
+		$settings = get_option( 'rsd_wordpress_settings', array() );
+		$img_url  = isset( $settings['img_url'] ) ? $settings['img_url'] : '';
+		?>
+		<div id="rsd-default-img-preview" class="rsd-image-preview">
+			<img src="<?php echo esc_url( $img_url ); ?>" alt="" class="<?php echo esc_attr( empty( $img_url ) ? 'hidden' : '' ); ?>">
+		</div>
+		<input type="text" id="rsd-default-img-url" name="rsd_wordpress_settings[img_url]" value="<?php echo esc_attr( $img_url ); ?>" class="regular-text">
+		<button type="button" class="button" id="rsd-select-default-img"><?php esc_html_e( 'Select image', 'rsd-wordpress' ); ?></button>
+		<button id="rsd-remove-default-img" type="button" class="button button-secondary reset<?php echo esc_attr( empty( $img_url ) ? ' hidden' : '' ); ?>">
+			<?php esc_html_e( 'Remove image', 'rsd-wordpress' ); ?>
+		</button>
+		<p class="description"><?php esc_html_e( 'The default image URL to be used for items without an image.', 'rsd-wordpress' ); ?></p>
+		<?php
 	}
 }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -168,15 +168,22 @@ class Plugin {
 	 * Enqueue plugin admin scripts and styles.
 	 */
 	public static function enqueue_admin_scripts() {
-		// Enqueue compiled stylesheet and scripts, using minified versions in production and staging environments.
-		$suffix = ( wp_get_environment_type() === 'production' || wp_get_environment_type() === 'staging' ? '.min' : '' );
-		wp_enqueue_script(
-			self::get_plugin_name() . '-admin',
-			RSD_WP__PLUGIN_URL . 'dist/rsd-wordpress-admin' . $suffix . '.js',
-			array( 'jquery' ),
-			self::get_version(),
-			true
-		);
+		// Only enqueue the script on the specific admin page where it's needed.
+		$current_screen = get_current_screen();
+
+		if ( false !== strpos( $current_screen->id, 'rsd-wordpress' ) ) :
+			wp_enqueue_media();
+
+			// Enqueue compiled stylesheet and scripts, using minified versions in production and staging environments.
+			$suffix = ( wp_get_environment_type() === 'production' || wp_get_environment_type() === 'staging' ? '.min' : '' );
+			wp_enqueue_script(
+				self::get_plugin_name() . '-admin',
+				RSD_WP__PLUGIN_URL . 'dist/rsd-wordpress-admin' . $suffix . '.js',
+				array( 'jquery' ),
+				self::get_version(),
+				true
+			);
+		endif;
 	}
 
 	/**

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -170,14 +170,21 @@ class Plugin {
 	public static function enqueue_admin_scripts() {
 		// Only enqueue the script on the specific admin page where it's needed.
 		$current_screen = get_current_screen();
-
 		if ( false !== strpos( $current_screen->id, 'rsd-wordpress' ) ) :
+			// Enqueue media scripts for the media uploader.
 			wp_enqueue_media();
 
 			// Enqueue compiled stylesheet and scripts, using minified versions in production and staging environments.
+			$handle = self::get_plugin_name() . '-admin';
 			$suffix = ( wp_get_environment_type() === 'production' || wp_get_environment_type() === 'staging' ? '.min' : '' );
+			wp_enqueue_style(
+				$handle,
+				RSD_WP__PLUGIN_URL . 'dist/rsd-wordpress-admin' . $suffix . '.css',
+				array(),
+				self::get_version()
+			);
 			wp_enqueue_script(
-				self::get_plugin_name() . '-admin',
+				$handle,
 				RSD_WP__PLUGIN_URL . 'dist/rsd-wordpress-admin' . $suffix . '.js',
 				array( 'jquery' ),
 				self::get_version(),

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -74,6 +74,7 @@ class Settings {
 					'organisation'   => __( 'Partners', 'rsd-wordpress' ),
 				),
 			),
+			'img_url' => 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7', // 1x1 transparent GIF.
 		);
 
 		if ( null === $key ) {
@@ -112,9 +113,25 @@ class Settings {
 				}
 			}
 			return $values;
+		} elseif ( 'img_url' === $key ) {
+			// Return the configured default image URL.
+			if ( isset( $settings['img_url'] ) && ! empty( $settings['img_url'] ) ) {
+				return $settings['img_url'];
+			} else {
+				return self::get_defaults( 'img_url' );
+			}
 		}
 
 		// Return any other requested settings.
 		return isset( $settings[ $key ] ) ? $settings[ $key ] : array();
+	}
+
+	/**
+	 * Get the default image URL from settings.
+	 *
+	 * @return string
+	 */
+	public static function get_default_image_url() {
+		return self::get_settings( 'img_url' );
 	}
 }

--- a/includes/public/class-display.php
+++ b/includes/public/class-display.php
@@ -22,13 +22,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class Display {
 	/**
-	 * Default image URL.
-	 *
-	 * @var string
-	 */
-	private static $default_img_url = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-
-	/**
 	 * The single instance of the class.
 	 *
 	 * @var Display|null
@@ -47,15 +40,6 @@ class Display {
 		}
 
 		return self::$instance;
-	}
-
-	/**
-	 * Get the default image URL.
-	 *
-	 * @return string
-	 */
-	public static function get_default_image_url() {
-		return self::$default_img_url;
 	}
 
 	/**
@@ -332,7 +316,7 @@ class Display {
 		$last_updated_local = $item->get_last_updated( $use_wp_timezone );
 
 		if ( empty( $image_url ) ) {
-			$image_url = self::get_default_image_url();
+			$image_url = Settings::get_default_image_url();
 		}
 
 		ob_start();
@@ -394,7 +378,7 @@ class Display {
 		$progress_date_format = 'M Y';
 
 		if ( empty( $image_url ) ) {
-			$image_url = self::get_default_image_url();
+			$image_url = Settings::get_default_image_url();
 		}
 
 		ob_start();

--- a/src/css/admin.css
+++ b/src/css/admin.css
@@ -1,0 +1,30 @@
+/**
+ * RSD WordPress plugin styles - admin area.
+ *
+ * @package RSD_WP
+ * @license Apache-2.0
+ * @link https://research-software-directory.org
+ */
+
+.settings_page_rsd-wordpress button.reset {
+	color: #b32d2e;
+	text-decoration: none;
+	border-color: transparent;
+	box-shadow: none;
+	background: 0 0;
+}
+
+.settings_page_rsd-wordpress button.reset:focus,
+.settings_page_rsd-wordpress button.reset:hover {
+	background: #b32d2e;
+	color: #fff;
+	border-color: #b32d2e;
+	box-shadow: 0 0 0 1px #b32d2e;
+}
+
+.settings_page_rsd-wordpress .rsd-image-preview img:not(.hidden) {
+	display: block;
+	max-width: 100%;
+	max-height: 250px;
+	margin-bottom: 1rem;
+}

--- a/src/index-admin.js
+++ b/src/index-admin.js
@@ -6,3 +6,9 @@
  */
 
 'use strict';
+
+// Import SCSS styles.
+import './css/admin.css';
+
+// Import JS components.
+import './js/admin-settings.js';

--- a/src/js/admin-settings.js
+++ b/src/js/admin-settings.js
@@ -1,0 +1,58 @@
+/**
+ * RSD WordPress plugin JavaScript for admin settings.
+ *
+ * @module rsd-wordpress
+ */
+
+'use strict';
+
+// Main function, executed when the page is loaded.
+( function ( $ ) {
+	let frame;
+	const $imgUrl = $( '#rsd-default-img-url' ),
+		$imgPreview = $( '#rsd-default-img-preview img' ),
+		$selectButton = $( '#rsd-select-default-img' ),
+		$removeButton = $( '#rsd-remove-default-img' );
+
+	function setImageUrl( url ) {
+		$imgUrl.val( url );
+
+		if ( url ) {
+			$imgPreview.removeClass( 'hidden' ).attr( 'src', url );
+			$removeButton.removeClass( 'hidden' );
+		} else {
+			$imgPreview.addClass( 'hidden' ).attr( 'src', '' );
+			$removeButton.addClass( 'hidden' );
+		}
+	}
+
+	$selectButton.on( 'click', function ( e ) {
+		e.preventDefault();
+		if ( frame ) {
+			frame.open();
+			return;
+		}
+
+		// Define frame as wp.media object
+		frame = wp.media( {
+			title: 'Choose an image',
+			multiple: false,
+			library: { type: 'image' },
+			button: { text: 'Select image' },
+		} );
+		frame.on( 'select', function () {
+			const selection = frame.state().get( 'selection' ).first() || false;
+			if ( ! selection ) {
+				return;
+			}
+			setImageUrl( selection.toJSON().url );
+		} );
+
+		frame.open();
+	} );
+
+	$removeButton.on( 'click', function ( e ) {
+		e.preventDefault();
+		setImageUrl( '' );
+	} );
+} )( jQuery.noConflict() );


### PR DESCRIPTION
This pull request adds a new default image URL option to the plugin settings in the WordPress admin. Key updates include:

- Introduced a default image URL setting with a getter method in the `Settings` class for flexible configuration.
- Implemented JavaScript for dynamic settings page interactions, currently used on the RSD Settings admin page only.
- Added `admin.css` for improved admin UI styling.
- Enqueued new CSS and JS files specifically for the admin area.