### PR TITLE
Replace Choices.js with Tom Select

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "vite": "^5.3.2"
   },
   "dependencies": {
-    "choices.js": "^10.2.0"
+    "tom-select": "^2.3.1"
   }
 }

--- a/src/css/rsd-wordpress.css
+++ b/src/css/rsd-wordpress.css
@@ -311,6 +311,11 @@ input[type="search"].rsd-search-input {
 
 /* Component style overrides */
 
+/* Tom Select */
+.ts-wrapper.multi .ts-control > div {
+	padding-left: 0.5rem;
+}
+
 /* Choices.js */
 .choices[data-type*="select-one"] .choices__input {
 	border-radius: 0;

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@
 'use strict';
 
 // Import styles.
-import 'choices.js/public/assets/styles/choices.min.css';
+import 'tom-select/dist/css/tom-select.css';
 import './css/rsd-wordpress.css';
 
 // Import JS components.

--- a/src/js/display/ui.js
+++ b/src/js/display/ui.js
@@ -4,7 +4,7 @@
 
 import DOM from '../helpers/dom';
 import Controller from '../services/controller';
-import Choices from 'choices.js';
+import TomSelect from 'tom-select';
 
 let instance = null;
 
@@ -79,14 +79,11 @@ class UI {
 				$placeholder.remove();
 			}
 
-			self.selectInstances[ identifier ] = new Choices( this, {
-				searchEnabled: false,
-				searchFields: [ 'value' ],
-				itemSelectText: '',
-				removeItemButton: true,
-				placeholder: true,
-				placeholderValue: placeholderStr,
-				searchPlaceholderValue: placeholderStr,
+			self.selectInstances[ identifier ] = new TomSelect( this, {
+				create: false,
+				searchField: [ 'value' ],
+				placeholder: placeholderStr,
+				plugins: [ 'remove_button' ],
 			} );
 		} );
 	}
@@ -96,22 +93,17 @@ class UI {
 			const selectInst = this.selectInstances[ identifier ];
 			if ( selectInst ) {
 				// Clear the filter.
-				selectInst.clearStore();
+				selectInst.clearOptions();
+
+				// Prepare the new filter values.
+				const items = filter.getItems().map( ( item ) => ( {
+					value: item.name,
+					text: filter.getLabel( item.name ),
+				} ) );
+
 				// Add the new filter values.
-				const items = filter.getItems().map( ( item ) => {
-					const isSelected =
-						Controller.currentFilters[ identifier ] &&
-						Controller.currentFilters[ identifier ].includes(
-							item.name
-						);
-					return {
-						value: item.name,
-						label: filter.getLabel( item.name ),
-						selected: isSelected,
-					};
-				} );
-				// Add the new filter values.
-				selectInst.setChoices( items, 'value', 'label', true );
+				selectInst.addOptions( items );
+				selectInst.refreshOptions( false );
 			}
 		} );
 	}

--- a/src/js/display/ui.js
+++ b/src/js/display/ui.js
@@ -4,7 +4,10 @@
 
 import DOM from '../helpers/dom';
 import Controller from '../services/controller';
-import TomSelect from 'tom-select';
+import TomSelect from 'tom-select/dist/js/tom-select.base.js';
+import TomSelectRemoveButton from 'tom-select/dist/js/plugins/remove_button.js';
+
+TomSelect.define( 'remove_button', TomSelectRemoveButton );
 
 let instance = null;
 

--- a/src/js/helpers/eventhandlers.js
+++ b/src/js/helpers/eventhandlers.js
@@ -37,6 +37,10 @@ async function clearFilters( reloadResults = true, clearSearch = true ) {
 		DOM.$container.find( '.rsd-search-input' ).val( '' );
 	}
 	DOM.$container.find( '.rsd-filters select' ).val( '' );
+	// Clear Tom Select values
+	Object.values( UI.selectInstances ).forEach( ( selectInst ) => {
+		selectInst.clear();
+	} );
 
 	Controller.clearCurrentFilters();
 


### PR DESCRIPTION
[Choices.js](https://github.com/Choices-js/Choices), the multi-select component that was introduced in pull #20, resulted in a JS production build file of ~120 KB, compared to a file size of ~18 KB before the component was included.

To minimize the JS production build size, this pull request swaps Choices.js with [Tom Select](https://github.com/orchidjs/tom-select), which is smaller in build size and also allows importing its base + plugins used only. Both libraries are vanilla JS and have similar features. The latest versions for Choices.js and Tom Select have been released in 2022 and 2023 respectively.

Using Tom Select in the way suggested in this pull request, the project build JS bundle file size is reduced to either ~69 KB (regular import) or ~62 KB (base + used plugins) total.

Note: the only other contestant for a suitable multi-select component would be [Select2](https://github.com/select2/select2), which depends on jQuery and had its last release in 2020.