### PR TITLE
Fix lint errors and clarify README shortcode examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,88 +1,109 @@
 # Research Software Directory plugin for WordPress
 
-This repo contains a WordPress integration of the Projects and Software overview for the Research Software Directory, using the RSD API.
+This repo contains a WordPress integration of the Projects and Software overview for the [Research Software Directory](https://research-software-directory.org/), using the RSD API.
 
 ## How to use the plugin
 
-To display the overview (e.g. for the Software section for the Netherlands eScience Center organisation) on your Wordpress site, use one of the following shortcode examples in any post or page:
-```shell
-[research_software_directory section="software" organisation="35c17f17-6b5f-4385-aa8b-6b1d33a10157"]
+To display the overview on your WordPress site, add the shortcode to any post or page. For example, the Software section for the Netherlands eScience Center organisation:
+
+```text
+[research_software_directory section="software" organisation-id="35c17f17-6b5f-4385-aa8b-6b1d33a10157"]
 ```
 
-To show the Projects section for the Netherlands eScience Center:
-```shell
-[research_software_directory section="projects" organisation="35c17f17-6b5f-4385-aa8b-6b1d33a10157"]
+To show the Projects section instead:
+
+```text
+[research_software_directory section="projects" organisation-id="35c17f17-6b5f-4385-aa8b-6b1d33a10157"]
 ```
 
-To limit the initial amount of nine items at page load:
-```shell
-[research_software_directory section="software" limit="9" organisation="35c17f17-6b5f-4385-aa8b-6b1d33a10157"]
+To limit the initial number of items shown at page load to nine:
+
+```text
+[research_software_directory section="software" limit="9" organisation-id="35c17f17-6b5f-4385-aa8b-6b1d33a10157"]
 ```
 
-### Exporting production ready plugin bundle
+### Shortcode attributes
 
-To create a smaller, production-ready ZIP file of all the plugin files without any development related files, use the project `export` script:
-```shell
-# First install the required Node.js dependencies
-$ pnpm install
+| Attribute         | Description                                      | Default                                  |
+|-------------------|--------------------------------------------------|------------------------------------------|
+| `section`         | Which overview to display: `software` or `projects` | `software`                            |
+| `organisation-id` | The RSD organisation UUID to show items for      | Netherlands eScience Center organisation |
+| `limit`           | Number of items to show at initial page load     | `48`                                     |
 
-# Export ZIP file to `/export` folder
-$ pnpm run export
-```
+Note: the shortcode only works in post or page content (not in widgets or template files), since the plugin's assets are only loaded when the shortcode is detected in the content.
 
-The folder extracted from the ZIP file, which contains the plugin files required for production, can then be used to deploy to a production server.
+### Plugin settings
 
-### Deployment or testing: build compiled bundle files first
-
-The current configuration uses [Vite](https://vitejs.dev/) to build the plugin front end assets, CSS and JS. Before using the plugin in a production environment (which is the default), make sure to run the build script:
-```shell
-# First install the required Node.js dependencies
-$ pnpm install
-
-# Run the build script for production
-$ pnpm run build
-``` 
-
-This will create minified CSS and JS bundle files according to the project's [Browserslist](https://browsersl.ist/) configuration, and uses [Autoprefixer](https://github.com/postcss/autoprefixer) and [Babel](https://babeljs.io/) to create cross-browser compatible code.
-
-_Note: See the section below for instructions on how to do this for a development environment._
+After activating the plugin, go to **Settings → Research Software Directory** in the WordPress admin to configure which filters are shown for each section and to set a default image for items without one.
 
 ## Local development
 
+### Requirements
+
+- Node.js >= 22 (see `.nvmrc`) and [pnpm](https://pnpm.io/) for building the front end assets
+- Composer for the PHP coding standards tooling
+
 ### Installing the plugin in WordPress
 
-This plugin can be used in a new or existing WordPress intallation in a local development environment. For a super quick testing environment, the bundled `docker-compose.yml` can be used with the application [Local](https://localwp.com/).
+This plugin can be used in a new or existing WordPress installation in a local development environment. For a super quick testing environment, the bundled `docker-compose.yml` can be used with the application [Local](https://localwp.com/).
 
-First make sure your WordPress installation is functional, then move the plugin file to the `plugins` folder of your installation, which is usually something like `<wordpress_folder>/wp-content/plugins/`.
+First make sure your WordPress installation is functional, then move the plugin folder to the `plugins` folder of your installation, which is usually something like `<wordpress_folder>/wp-content/plugins/`.
 
-### Building compiled bundle files for development
+### Building the bundle files
 
-Similar to the above example, before using the plugin in a development environment, make sure to run the build script (which uses watch mode automatically):
+The project uses [Vite](https://vitejs.dev/) to build the plugin front end assets (CSS and JS) into the `dist/` folder. Production builds are minified (`.min` suffix) according to the project's [Browserslist](https://browsersl.ist/) configuration, using [Autoprefixer](https://github.com/postcss/autoprefixer) and [Babel](https://babeljs.io/) for cross-browser compatible code.
+
+Which files WordPress loads depends on the environment: minified `.min` bundles are used when `wp_get_environment_type()` is `production` or `staging`, and unminified bundles otherwise. So make sure to run the build that matches your environment:
 
 ```shell
 # First install the required Node.js dependencies
 $ pnpm install
 
-# Run the build script for production
+# Development build in watch mode (unminified)
 $ pnpm run dev
-``` 
 
-### Editor configuration
+# Production build (minified, with sourcemaps)
+$ pnpm run build
+```
+
+### Coding standards and linting
 
 This project uses [EditorConfig](https://editorconfig.org/) to maintain a consistent coding style. Please make sure your editor applies this configuration to any of your code changes for this repo.
 
-### WordPress Coding Standards
+JavaScript is linted with ESLint, using the [WordPress ESLint plugin](https://www.npmjs.com/package/@wordpress/eslint-plugin):
 
-To ensure code quality and adherence to coding conventions, before committing any changes to the code of this project, please use `phpcs` (see [WordPress Coding Standards for PHP_CodeSniffer](https://github.com/WordPress/WordPress-Coding-Standards)) with the bundled PHP_CS configuration file.
-
-You can also use the bundled project PHP_CS configuration by running:
 ```shell
-# Install PHP_CS and related packages
+# Check all JS files in src/
+$ pnpm run lint
+
+# Automatically fix violations where possible
+$ pnpm run lint:fix
+```
+
+PHP follows the [WordPress Coding Standards](https://github.com/WordPress/WordPress-Coding-Standards), checked with PHP_CodeSniffer using the bundled `.phpcs.xml` configuration. Please run it before committing any PHP changes:
+
+```shell
+# Install PHP_CodeSniffer and related packages
 $ composer install
 
-# Run PHP_CS to check all PHP files in the project
+# Run PHPCS to check all PHP files in the project
 $ composer run lint
 
 # Or use PHP Code Beautifier and Fixer to automatically correct coding standard violations
 $ composer run format
 ```
+
+## Exporting a production-ready plugin bundle
+
+To create a smaller, production-ready ZIP file of all the plugin files without any development related files, use the project `export` script:
+
+```shell
+# Export ZIP file to the export/ folder
+$ pnpm run export
+```
+
+The folder extracted from the ZIP file, which contains the plugin files required for production, can then be used to deploy to a production server.
+
+## License
+
+This plugin is licensed under the [Apache License 2.0](LICENSE).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,7 @@ export default [
 		},
 		rules: {
 			'no-console': 'off',
+			'prettier/prettier': 'warn',
 			indent: [ 'error', 'tab' ],
 			'linebreak-style': [ 'error', 'unix' ],
 			quotes: [ 'error', 'single' ],

--- a/src/js/components/item.js
+++ b/src/js/components/item.js
@@ -98,7 +98,9 @@ export default class Item {
 		dateStr,
 		format = { year: 'numeric', month: '2-digit', day: '2-digit' }
 	) {
-		if ( ! dateStr ) return '';
+		if ( ! dateStr ) {
+			return '';
+		}
 
 		const date = new Date( dateStr );
 		const formatter = new Intl.DateTimeFormat( 'en-UK', format );

--- a/src/js/services/controller.js
+++ b/src/js/services/controller.js
@@ -135,7 +135,6 @@ class Controller {
 				type: 'GET',
 				url: API.getUrl( path, params ),
 				headers: { Prefer: 'count=exact' },
-				// eslint-disable-next-line object-shorthand
 				success: ( response ) => {
 					// Create an array of Item objects from the response.
 					const resultItems = [];
@@ -157,7 +156,6 @@ class Controller {
 
 					resolve( resultItems );
 				},
-				// eslint-disable-next-line object-shorthand
 				error: ( jqXHR, textStatus, errorThrown ) => {
 					reject( errorThrown );
 				},
@@ -285,7 +283,6 @@ class Controller {
 					data: JSON.stringify( data.params ),
 					dataType: 'json',
 					contentType: 'application/json',
-					// eslint-disable-next-line object-shorthand
 					success: ( response ) => {
 						filters[ filter ] = new Filter(
 							data.title,
@@ -295,7 +292,6 @@ class Controller {
 						);
 						resolve();
 					},
-					// eslint-disable-next-line object-shorthand
 					error: ( jqXHR, textStatus, errorThrown ) => {
 						reject( errorThrown );
 					},


### PR DESCRIPTION
Fixes lint errors and warnings seen after the `eslint-flat-config-vite8` upgrade, plus a follow-up `README` correction.

- Restores `'prettier/prettier': 'warn'` in `eslint.config.js`, which was dropped during the `.eslintrc.json` → flat config migration and had turned prettier formatting issues into hard errors instead of warnings.
- Adds braces to a one-line `if` in `item.js` (`curly` rule).
- Removes four stale `eslint-disable-next-line object-shorthand` comments in `controller.js` that no longer suppress anything.
- Updates `README.md` shortcode examples to use `organisation-id` instead of `organisation`, matching the actual attribute read by `Controller` in `class-plugin.php`, and general clarity improvements.

**Remaining known issue:** four `prettier/prettier` warnings remain in `item.js` for long template-literal lines exceeding the 80-char print width. Running `--fix` on them triggers an ESLint "circular fixes" loop between `prettier/prettier` and the `indent` rule inside template-literal interpolations, producing broken indentation, so they were left as-is (they were warnings, not errors, already present earlier).

**Testing**

- `pnpm run lint` exits `0` with zero errors (four pre-existing warnings remain, noted above).
- `pnpm run build` produces working output with no size regressions.
