### PR TITLE
Fix XSS in client-side rendering and harden API error handling

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,7 @@
 
 import wordpress from '@wordpress/eslint-plugin';
 import compat from 'eslint-plugin-compat';
+import noUnsanitized from 'eslint-plugin-no-unsanitized';
 import globals from 'globals';
 
 export default [
@@ -27,6 +28,9 @@ export default [
 				rsdWordPressVars: 'readonly',
 			},
 		},
+		plugins: {
+			'no-unsanitized': noUnsanitized,
+		},
 		rules: {
 			'no-console': 'off',
 			'prettier/prettier': 'warn',
@@ -34,6 +38,28 @@ export default [
 			'linebreak-style': [ 'error', 'unix' ],
 			quotes: [ 'error', 'single' ],
 			semi: [ 'error', 'always' ],
+			'no-unsanitized/property': 'error',
+			'no-unsanitized/method': [
+				'error',
+				{
+					escape: {
+						// API data interpolated into HTML must go through escapeHtml()
+						// from helpers/utils.js. Item.getLabels()/getProps() return
+						// HTML that is escaped internally.
+						methods: [ 'escapeHtml', 'item.getLabels', 'item.getProps' ],
+					},
+				},
+				{
+					// Also check jQuery DOM-insertion methods (the default set only
+					// covers native APIs such as insertAdjacentHTML).
+					append: { properties: [ 0 ] },
+					prepend: { properties: [ 0 ] },
+					before: { properties: [ 0 ] },
+					after: { properties: [ 0 ] },
+					html: { properties: [ 0 ] },
+					replaceWith: { properties: [ 0 ] },
+				},
+			],
 		},
 	},
 ];

--- a/includes/admin/class-settings-admin.php
+++ b/includes/admin/class-settings-admin.php
@@ -87,7 +87,14 @@ class Settings_Admin extends \RSD\Settings {
 	 * @return void
 	 */
 	public static function init() {
-		register_setting( 'rsd-wordpress', 'rsd_wordpress_settings' );
+		register_setting(
+			'rsd-wordpress',
+			'rsd_wordpress_settings',
+			array(
+				'type'              => 'array',
+				'sanitize_callback' => array( __CLASS__, 'sanitize_settings' ),
+			)
+		);
 
 		add_settings_section(
 			'rsd_filters_section',
@@ -126,6 +133,36 @@ class Settings_Admin extends \RSD\Settings {
 			'rsd-wordpress',
 			'rsd_images_section'
 		);
+	}
+
+	/**
+	 * Sanitize the settings before saving.
+	 *
+	 * @param mixed $settings The raw settings value as submitted.
+	 * @return array The sanitized settings.
+	 */
+	public static function sanitize_settings( $settings ) {
+		$sanitized = array();
+
+		if ( ! is_array( $settings ) ) {
+			return $sanitized;
+		}
+
+		// Only keep known filter identifiers for each section.
+		foreach ( array( 'software', 'projects' ) as $section ) {
+			$key = $section . '_default_filters';
+			if ( ! empty( $settings[ $key ] ) && is_array( $settings[ $key ] ) ) {
+				$valid             = array_keys( self::get_defaults( 'filters', $section ) );
+				$sanitized[ $key ] = array_values( array_intersect( $settings[ $key ], $valid ) );
+			}
+		}
+
+		// The default image URL must be a valid URL.
+		if ( ! empty( $settings['img_url'] ) ) {
+			$sanitized['img_url'] = esc_url_raw( $settings['img_url'] );
+		}
+
+		return $sanitized;
 	}
 
 	/**

--- a/includes/admin/class-settings-admin.php
+++ b/includes/admin/class-settings-admin.php
@@ -9,6 +9,9 @@
 
 namespace RSD\Admin;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Plugin settings class.
  *

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -8,6 +8,9 @@
 
 namespace RSD;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Plugin settings class.
  *

--- a/includes/controller/class-api.php
+++ b/includes/controller/class-api.php
@@ -146,7 +146,7 @@ class Api {
 	 * @param string $path The path.
 	 * @param array  $args The arguments.
 	 * @param bool   $retrieve_headers Whether to retrieve the headers.
-	 * @return array The API response data and headers.
+	 * @return array|\WP_Error The API response data and headers, or a WP_Error on request failure.
 	 */
 	public static function get_response( $path, $args = array(), $retrieve_headers = false ) {
 		// Call the API.
@@ -154,7 +154,7 @@ class Api {
 		$response = wp_remote_get( $url, $args );
 
 		if ( is_wp_error( $response ) ) {
-			return 'Error: ' . $response->get_error_message();
+			return $response;
 		}
 
 		// Decode the API response.

--- a/includes/controller/class-controller.php
+++ b/includes/controller/class-controller.php
@@ -523,13 +523,17 @@ class Controller {
 			// Build the API path.
 			$path = Api::build_path( $filter['path'], $filter['params'] );
 
-			// Get the API response.
+			// Get the API response, skipping this filter if the request failed.
 			$response = Api::get_response( $path );
+			if ( is_wp_error( $response ) ) {
+				continue;
+			}
 
 			// Process data.
+			$data           = ( is_array( $response['data'] ) ? $response['data'] : array() );
 			$args           = ( ! empty( $filter['args'] ) ? $filter['args'] : array() );
 			$id             = $filter['identifier'];
-			$filters[ $id ] = new Filter( $filter['title'], $filter['identifier'], $response['data'], $args );
+			$filters[ $id ] = new Filter( $filter['title'], $filter['identifier'], $data, $args );
 
 			// Additionally retrieve and set labels for specific filter(s).
 			if ( 'domain' === $id ) {
@@ -542,11 +546,13 @@ class Controller {
 				);
 				$response = Api::get_response( $path );
 
-				$labels = array();
-				foreach ( $response['data'] as $item ) {
-					$labels[ $item['key'] ] = $item['name'];
+				if ( ! is_wp_error( $response ) && is_array( $response['data'] ) ) {
+					$labels = array();
+					foreach ( $response['data'] as $item ) {
+						$labels[ $item['key'] ] = $item['name'];
+					}
+					$filters[ $id ]->set_labels( $labels );
 				}
-				$filters[ $id ]->set_labels( $labels );
 			} elseif ( 'project_status' === $id ) {
 				// Remove 'unknown' status from items.
 				$filters[ $id ]->remove_item( 'unknown' );
@@ -671,8 +677,11 @@ class Controller {
 
 		// Get the API response.
 		$response = Api::get_response( $path, $args, true );
-		$headers  = $response['headers'];
-		$data     = $response['data'];
+		if ( is_wp_error( $response ) ) {
+			return false;
+		}
+		$headers = $response['headers'];
+		$data    = $response['data'];
 
 		// Process data.
 		$items = array();

--- a/includes/models/class-software-item.php
+++ b/includes/models/class-software-item.php
@@ -191,32 +191,4 @@ class Software_Item extends Item {
 	public function get_closed_source() {
 		return $this->closed_source;
 	}
-
-	/**
-	 * Get the item programming language(s) as a string.
-	 *
-	 * @since 0.1.0
-	 * @return string
-	 */
-	public function get_prog_lang_string() {
-		if ( is_array( $this->prog_lang ) && count( $this->prog_lang ) > 0 ) {
-			return implode( ', ', $this->prog_lang );
-		} else {
-			return array();
-		}
-	}
-
-	/**
-	 * Get the item licenses as a string.
-	 *
-	 * @since 0.1.0
-	 * @return string
-	 */
-	public function get_licenses_string() {
-		if ( is_array( $this->licenses ) && count( $this->licenses ) > 0 ) {
-			return implode( ', ', $this->licenses );
-		} else {
-			return array();
-		}
-	}
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "concurrently": "^10.0.3",
     "eslint": "^10.6.0",
     "eslint-plugin-compat": "^7.0.2",
+    "eslint-plugin-no-unsanitized": "^4.1.5",
     "globals": "^17.7.0",
     "lightningcss": "^1.32.0",
     "path": "^0.12.7",

--- a/src/js/components/item.js
+++ b/src/js/components/item.js
@@ -2,7 +2,7 @@
  * Item component
  */
 
-import { getSlugFromURL } from '../helpers/utils';
+import { getSlugFromURL, escapeHtml } from '../helpers/utils';
 import Controller from '../services/controller';
 
 export default class Item {
@@ -42,12 +42,16 @@ export default class Item {
 	}
 
 	getUrl() {
-		return `https://research-software-directory.org/${ Controller.section }/${ this.slug }`;
+		return `https://research-software-directory.org/${
+			Controller.section
+		}/${ encodeURIComponent( this.slug ) }`;
 	}
 
 	getImgUrl() {
 		if ( this.image_id ) {
-			return `https://research-software-directory.org/image/rpc/get_image?uid=${ this.image_id }`;
+			return `https://research-software-directory.org/image/rpc/get_image?uid=${ encodeURIComponent(
+				this.image_id
+			) }`;
 		} else if ( rsdWordPressVars.defaultImgUrl ) {
 			return rsdWordPressVars.defaultImgUrl;
 		}
@@ -142,7 +146,7 @@ export default class Item {
 	getLabels() {
 		let html = '<ul class="rsd-results-item-labels">';
 		$.each( this.keywords, function ( index, label ) {
-			html += `<li class="label">${ label }</li>`;
+			html += `<li class="label">${ escapeHtml( label ) }</li>`;
 		} );
 		html += '</ul>';
 
@@ -158,22 +162,32 @@ export default class Item {
 		};
 
 		$.each( props, function ( prop, obj ) {
+			const value = escapeHtml( obj.value );
+			const label = escapeHtml( obj.label );
+
 			if ( 'progress' === prop ) {
+				const dateStart = escapeHtml(
+					self.getDateStart( progressDateFormat )
+				);
+				const dateEnd = escapeHtml(
+					self.getDateEnd( progressDateFormat )
+				);
 				html += `
-					<li class="rsd-results-item-prop-progress" data-progress-percentage="${ obj.value }">
-						<span class="value date-start">${ self.getDateStart( progressDateFormat ) }</span> -
-						<span class="value date-end">${ self.getDateEnd( progressDateFormat ) }</span>
-						<div class="progress-bar" role="progressbar" tabindex="0" aria-valuenow="${ obj.value }" aria-valuemin="0" aria-valuemax="100">
-							<div class="progress-meter" style="width: ${ obj.value }%;"></div>
+					<li class="rsd-results-item-prop-progress" data-progress-percentage="${ value }">
+						<span class="value date-start">${ dateStart }</span> -
+						<span class="value date-end">${ dateEnd }</span>
+						<div class="progress-bar" role="progressbar" tabindex="0" aria-valuenow="${ value }" aria-valuemin="0" aria-valuemax="100">
+							<div class="progress-meter" style="width: ${ value }%;"></div>
 						</div>
 					</li>
 					`;
 			} else {
+				const propClass = escapeHtml( prop.toLowerCase() );
 				html += `
-					<li class="rsd-results-item-prop-${ prop.toLowerCase() }">
-						<span aria-hidden="true" class="icon icon-${ prop.toLowerCase() }" title="${ obj.label }"></span>
-						<span class="value">${ obj.value }</span>
-						<span class="prop">${ obj.label }</span>
+					<li class="rsd-results-item-prop-${ propClass }">
+						<span aria-hidden="true" class="icon icon-${ propClass }" title="${ label }"></span>
+						<span class="value">${ value }</span>
+						<span class="prop">${ label }</span>
 					</li>
 					`;
 			}

--- a/src/js/display/ui.js
+++ b/src/js/display/ui.js
@@ -199,17 +199,12 @@ class UI {
 				};
 			}
 
-			let imageContainAttr = '';
-			if ( item.getImageContain() ) {
-				imageContainAttr = ' class="contain"';
-			}
-
 			// prettier-ignore
 			$itemsContainer.append( `
 				<div class="rsd-results-item column card in-viewport" data-id="${ escapeHtml( item.getId() ) }" data-last-updated="${ escapeHtml( item.getLastUpdated() ) }">
 					<div class="card-image">
 						<a href="${ escapeHtml( item.getUrl() ) }" target="_blank" rel="external"><img src="${ escapeHtml( item.getImgUrl() ) }"
-							 alt="" title="${ escapeHtml( title ) }" aria-label="${ escapeHtml( title ) }"${ imageContainAttr }></a>
+							 alt="" title="${ escapeHtml( title ) }" aria-label="${ escapeHtml( title ) }" class="${ escapeHtml( item.getImageContain() ? 'contain' : '' ) }"></a>
 					</div>
 					<div class="card-section">
 						<h3><a href="${ escapeHtml( item.getUrl() ) }" target="_blank" rel="external">${ escapeHtml( title ) }</a></h3>

--- a/src/js/display/ui.js
+++ b/src/js/display/ui.js
@@ -69,6 +69,21 @@ class UI {
 			.text( `${ count } items found` );
 	}
 
+	showErrorMessage( message ) {
+		this.hideErrorMessage();
+		DOM.$container
+			.find( '.rsd-results-items' )
+			.before(
+				`<div class="rsd-results-error"><p>${ escapeHtml(
+					message
+				) }</p></div>`
+			);
+	}
+
+	hideErrorMessage() {
+		DOM.$container.find( '.rsd-results-error' ).remove();
+	}
+
 	enhanceFilterSelects() {
 		const self = this;
 

--- a/src/js/display/ui.js
+++ b/src/js/display/ui.js
@@ -4,6 +4,7 @@
 
 import DOM from '../helpers/dom';
 import Controller from '../services/controller';
+import { escapeHtml } from '../helpers/utils';
 import TomSelect from 'tom-select/dist/js/tom-select.base.js';
 import TomSelectRemoveButton from 'tom-select/dist/js/plugins/remove_button.js';
 
@@ -190,14 +191,14 @@ class UI {
 
 			// prettier-ignore
 			$itemsContainer.append( `
-				<div class="rsd-results-item column card in-viewport" data-id="${ item.getId() }" data-last-updated="${ item.getLastUpdated() }">
+				<div class="rsd-results-item column card in-viewport" data-id="${ escapeHtml( item.getId() ) }" data-last-updated="${ escapeHtml( item.getLastUpdated() ) }">
 					<div class="card-image">
-						<a href="${ item.getUrl() }" target="_blank" rel="external"><img src="${ item.getImgUrl() }"
-							 alt="" title="${ title }" aria-label="${ title }"${ imageContainAttr }></a>
+						<a href="${ escapeHtml( item.getUrl() ) }" target="_blank" rel="external"><img src="${ escapeHtml( item.getImgUrl() ) }"
+							 alt="" title="${ escapeHtml( title ) }" aria-label="${ escapeHtml( title ) }"${ imageContainAttr }></a>
 					</div>
 					<div class="card-section">
-						<h3><a href="${ item.getUrl() }" target="_blank" rel="external">${ title }</a></h3>
-						<p>${ description }</p>
+						<h3><a href="${ escapeHtml( item.getUrl() ) }" target="_blank" rel="external">${ escapeHtml( title ) }</a></h3>
+						<p>${ escapeHtml( description ) }</p>
 					</div>
 					<div class="card-footer">
 						<div class="rsd-results-item-specs">

--- a/src/js/helpers/eventhandlers.js
+++ b/src/js/helpers/eventhandlers.js
@@ -63,7 +63,7 @@ function enhanceFiltersSidebar() {
 
 	// Add close button to filters sidebar.
 	$sidebar.prepend( `
-		<button class="close-button" aria-label="Close alert" type="button"
+		<button class="close-button" aria-label="Close alert" type="button">
 			<span aria-hidden="true">&times;</span>
 		</button>
 	` );

--- a/src/js/helpers/utils.js
+++ b/src/js/helpers/utils.js
@@ -6,4 +6,14 @@ function getSlugFromURL( url ) {
 	return url.split( '/' ).pop();
 }
 
-export { getSlugFromURL };
+// Escape a value for safe interpolation into HTML content or attribute values.
+function escapeHtml( value ) {
+	return String( value )
+		.replace( /&/g, '&amp;' )
+		.replace( /</g, '&lt;' )
+		.replace( />/g, '&gt;' )
+		.replace( /"/g, '&quot;' )
+		.replace( /'/g, '&#039;' );
+}
+
+export { getSlugFromURL, escapeHtml };

--- a/src/js/services/controller.js
+++ b/src/js/services/controller.js
@@ -321,10 +321,14 @@ class Controller {
 			this.currentOffset = offset + this.items.length;
 
 			// Display the results.
+			UI.hideErrorMessage();
 			UI.displayResults( this.items, this.itemsTotal );
 			// Re-attach infinite scroll event.
 			enhanceResultsInfiniteScroll();
 		} catch ( error ) {
+			UI.showErrorMessage(
+				'Could not load results from the Research Software Directory. Please try again later.'
+			);
 			console.error( '🎹 Error fetching items: ', error );
 		}
 	}
@@ -350,8 +354,12 @@ class Controller {
 
 			// Append the results.
 			const appendItems = true;
+			UI.hideErrorMessage();
 			UI.displayResults( newItems, this.itemsTotal, appendItems );
 		} catch ( error ) {
+			UI.showErrorMessage(
+				'Could not load more results from the Research Software Directory. Please try again later.'
+			);
 			console.error( '🎹 Error fetching more items: ', error );
 		}
 	}


### PR DESCRIPTION
This PR fixes security issues found during a code review, plus a few small cleanups.

## Security

The main fix is an XSS vulnerability: the initial page load is rendered in PHP and properly escaped, but every search, filter, sort and infinite-scroll action re-renders the result cards in JS, and that path injects API data (`brand_name`, `short_statement`, `title`, `subtitle`, `keywords`) straight into HTML. Since RSD content is written by external contributors, that's a real injection vector. Now using the new `escapeHtml()` helper function, and `slug`/`image_id` are wrapped in `encodeURIComponent()` before ending up in URLs.

Related fixes on the same branch:

- `register_setting()` now has a `sanitize_callback`: filter identifiers are checked against the known set per section and the default image URL goes through `esc_url_raw()`.
- `Api::get_response()` used to return an error string on `WP_Error`, which every caller then indexed as an array, so an API outage produced PHP warnings instead of the intended "No data returned from API" message. It now returns the `WP_Error` and callers check for it. On the JS side, a failed fetch now shows an error notice to the visitor instead of only logging to the console.
- Added the missing `ABSPATH` guards to `Settings` and `Settings_Admin`.

To keep the escaping from regressing, ESLint now runs `eslint-plugin-no-unsanitized`, configured to also check jQuery DOM-insertion methods (`.append()`, `.html()`, etc.). Interpolating anything into HTML without `escapeHtml()` will now fail the lint.

## Cleanups

- The close button in the filters sidebar was missing the `>` after `type="button"`, producing garbled markup.
- Removed `get_prog_lang_string()` and `get_licenses_string()` from `Software_Item`; they had no callers and returned `array()` where their DocBlock promised a string.

## Testing

`composer run lint`, `pnpm run lint` and `pnpm run build` all pass. Smoke-tested in a local WordPress install with headless browser: searching re-renders the cards correctly (including keywords containing `&`, with no double-escaping), a mocked API response carrying `<script>`/`onerror`/attribute-breakout payloads in every field renders as inert text, and blocking the RSD API shows the new error notice, which clears again once the API is reachable. The settings page wasn't part of the smoke test, so the new `sanitize_callback` deserves a quick manual check when reviewing.
