### PR TITLE
Fix asset loading outside post content, progress bar, and external links

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -153,14 +153,19 @@ class Plugin {
 	public static function enqueue_public_scripts() {
 		global $post;
 
-		if ( ! is_a( $post, 'WP_Post' ) || ! has_shortcode( get_the_content(), 'research_software_directory' ) ) {
-			return;
-		}
-
-		// Enqueue compiled stylesheet and scripts, using minified versions in production and staging environments.
+		// Register compiled stylesheet and scripts, using minified versions in production and staging environments.
 		$suffix = ( wp_get_environment_type() === 'production' || wp_get_environment_type() === 'staging' ? '.min' : '' );
-		wp_enqueue_style( self::get_plugin_name() . '-public', RSD_WP__PLUGIN_URL . 'dist/rsd-wordpress' . $suffix . '.css', array(), self::get_version() );
-		wp_enqueue_script( self::get_plugin_name() . '-public', RSD_WP__PLUGIN_URL . 'dist/rsd-wordpress' . $suffix . '.js', array( 'jquery' ), self::get_version(), true );
+		wp_register_style( self::get_plugin_name() . '-public', RSD_WP__PLUGIN_URL . 'dist/rsd-wordpress' . $suffix . '.css', array(), self::get_version() );
+		wp_register_script( self::get_plugin_name() . '-public', RSD_WP__PLUGIN_URL . 'dist/rsd-wordpress' . $suffix . '.js', array( 'jquery' ), self::get_version(), true );
+
+		// Enqueue in the head when the shortcode is in the post content, so the
+		// initial render is styled without a flash of unstyled content. The
+		// shortcode handler also enqueues on render, as a fallback for widgets
+		// and template files where this detection does not apply.
+		if ( is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, 'research_software_directory' ) ) {
+			wp_enqueue_style( self::get_plugin_name() . '-public' );
+			wp_enqueue_script( self::get_plugin_name() . '-public' );
+		}
 	}
 
 	/**
@@ -228,6 +233,11 @@ class Plugin {
 
 		// Fetch the filters from API.
 		Controller::fetch_filters();
+
+		// Enqueue the registered assets (no-op if already enqueued in the head),
+		// so the shortcode also works from widgets and template files.
+		wp_enqueue_style( self::get_plugin_name() . '-public' );
+		wp_enqueue_script( self::get_plugin_name() . '-public' );
 
 		// Make filter labels available in JS.
 		$labels       = Controller::get_filter_labels();

--- a/includes/models/class-item.php
+++ b/includes/models/class-item.php
@@ -138,7 +138,10 @@ abstract class Item {
 	 * @return string
 	 */
 	public function get_last_updated( $use_wp_timezone = false, $format = 'U' ) {
-		$date = new \DateTimeImmutable( $this->get_updated_at() );
+		// Note: The UTC $timezone argument is added as a safety measure only:
+		// The API is expected to send timestamps including a UTC offset (+00:00),
+		// which takes precedence over the $timezone argument.
+		$date = new \DateTimeImmutable( $this->get_updated_at(), new \DateTimeZone( 'UTC' ) );
 
 		if ( $use_wp_timezone ) {
 			return wp_date( $format, $date->getTimestamp() );

--- a/includes/models/class-project-item.php
+++ b/includes/models/class-project-item.php
@@ -252,6 +252,9 @@ class Project_Item extends Item {
 		} else {
 			$total   = $date_start->diff( $date_end )->days;
 			$elapsed = $date_start->diff( $now )->days;
+			if ( 0 === $total ) {
+				return 100;
+			}
 			return round( ( $elapsed / $total ) * 100 );
 		}
 	}

--- a/includes/public/class-display.php
+++ b/includes/public/class-display.php
@@ -210,6 +210,8 @@ class Display {
 	public static function display_results( $items ) {
 		ob_start();
 
+		$sort_fields = array();
+
 		if ( 'projects' === Controller::get_section() ) {
 			$sort_fields = array(
 				'output_cnt' => __( 'Output', 'rsd-wordpress' ),

--- a/includes/public/class-display.php
+++ b/includes/public/class-display.php
@@ -323,11 +323,11 @@ class Display {
 		?>
 		<div class="rsd-results-item column card" data-id="<?php echo esc_attr( $item->get_id() ); ?>" data-last-updated="<?php echo esc_attr( $last_updated_local ); ?>">
 			<div class="card-image">
-				<a href="<?php echo esc_attr( $item_url ); ?>" target="_blank" rel="external"><img src="<?php echo esc_attr( $image_url ); ?>"
+				<a href="<?php echo esc_attr( $item_url ); ?>" target="_blank" rel="external noopener"><img src="<?php echo esc_attr( $image_url ); ?>"
 				alt="" title="<?php echo esc_attr( $title ); ?>" aria-label="<?php echo esc_attr( $aria_label ); ?>"></a>
 			</div>
 			<div class="card-section">
-				<h3><a href="<?php echo esc_attr( $item_url ); ?>" target="_blank" rel="external"><?php echo esc_html( $item->get_brand_name() ); ?></a></h3>
+				<h3><a href="<?php echo esc_attr( $item_url ); ?>" target="_blank" rel="external noopener"><?php echo esc_html( $item->get_brand_name() ); ?></a></h3>
 				<p><?php echo esc_html( mb_strimwidth( $item->get_short_statement(), 0, 100, '...' ) ); ?></p>
 			</div>
 			<div class="card-footer">
@@ -385,7 +385,7 @@ class Display {
 		?>
 		<div class="rsd-results-item column card" data-id="<?php echo esc_attr( $item->get_id() ); ?>" data-last-updated="<?php echo esc_attr( $last_updated_local ); ?>">
 			<div class="card-image">
-				<a href="<?php echo esc_attr( $item_url ); ?>" target="_blank" rel="external"><img src="<?php echo esc_attr( $image_url ); ?>"
+				<a href="<?php echo esc_attr( $item_url ); ?>" target="_blank" rel="external noopener"><img src="<?php echo esc_attr( $image_url ); ?>"
 				alt="" title="<?php echo esc_attr( $title ); ?>" aria-label="<?php echo esc_attr( $aria_label ); ?>"
 				<?php // phpcs:ignore
 				echo $image_contain_attr;
@@ -393,7 +393,7 @@ class Display {
 				></a>
 			</div>
 			<div class="card-section">
-				<h3><a href="<?php echo esc_attr( $item_url ); ?>" target="_blank" rel="external"><?php echo esc_html( $item->get_title() ); ?></a></h3>
+				<h3><a href="<?php echo esc_attr( $item_url ); ?>" target="_blank" rel="external noopener"><?php echo esc_html( $item->get_title() ); ?></a></h3>
 				<p><?php echo esc_html( mb_strimwidth( $item->get_subtitle(), 0, 100, '...' ) ); ?></p>
 			</div>
 			<div class="card-footer">

--- a/src/js/components/item.js
+++ b/src/js/components/item.js
@@ -137,6 +137,9 @@ export default class Item {
 
 			const total = ( dateEnd - dateStart ) / ( 1000 * 60 * 60 * 24 );
 			const elapsed = ( now - dateStart ) / ( 1000 * 60 * 60 * 24 );
+			if ( total <= 0 ) {
+				return 100;
+			}
 			return Math.round( ( elapsed / total ) * 100 );
 		}
 

--- a/src/js/display/ui.js
+++ b/src/js/display/ui.js
@@ -203,11 +203,11 @@ class UI {
 			$itemsContainer.append( `
 				<div class="rsd-results-item column card in-viewport" data-id="${ escapeHtml( item.getId() ) }" data-last-updated="${ escapeHtml( item.getLastUpdated() ) }">
 					<div class="card-image">
-						<a href="${ escapeHtml( item.getUrl() ) }" target="_blank" rel="external"><img src="${ escapeHtml( item.getImgUrl() ) }"
+						<a href="${ escapeHtml( item.getUrl() ) }" target="_blank" rel="external noopener"><img src="${ escapeHtml( item.getImgUrl() ) }"
 							 alt="" title="${ escapeHtml( title ) }" aria-label="${ escapeHtml( title ) }" class="${ escapeHtml( item.getImageContain() ? 'contain' : '' ) }"></a>
 					</div>
 					<div class="card-section">
-						<h3><a href="${ escapeHtml( item.getUrl() ) }" target="_blank" rel="external">${ escapeHtml( title ) }</a></h3>
+						<h3><a href="${ escapeHtml( item.getUrl() ) }" target="_blank" rel="external noopener">${ escapeHtml( title ) }</a></h3>
 						<p>${ escapeHtml( description ) }</p>
 					</div>
 					<div class="card-footer">


### PR DESCRIPTION
Small follow-up fixes from the code review in PR #24

## Changes

- Plugin assets are now registered unconditionally and enqueued from the shortcode handler as a fallback, so the shortcode also works from widgets and template files. Regular pages keep the head enqueue via content detection to avoid a flash of unstyled content; in the fallback case the CSS loads in the footer.
- `getProgressPercentage()` divided by zero when a project has the same start and end date, rendering "Infinity" in the progress bar. Both the PHP and JS implementations now return `100` for zero-day durations.
- `Item::get_last_updated()` passes an explicit UTC timezone when parsing API timestamps. Safety measure only: the API serves `TIMESTAMPTZ` values with a `+00:00` offset, which takes precedence over the argument; this pins the interpretation of hypothetical offset-less values.
- External item links (`target="_blank"`) now include `rel="noopener"` in both render paths, preventing reverse tabnabbing via `window.opener` in older browsers (modern browsers already imply it for `target="_blank"`).
- `Display::display_results()` left `$sort_fields` undefined when the shortcode gets an invalid `section` value, producing a PHP warning; it now initializes to an empty array.

## Testing

`composer run lint`, `pnpm run lint` and `pnpm run build` pass. Smoke-tested on a local WordPress install with a headless browser: the shortcode page renders and re-renders as before, all 96 external links in the served page carry `rel="external noopener"`, and the API-failure notice still appears and clears correctly. Note that the widget/template fallback for asset loading wasn't exercised live (no widget uses the shortcode locally), so do a quick check if you are planning to use that setup.
