### PR TITLE
Guard against multiple shortcode instances per page

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To limit the initial number of items shown at page load to nine:
 | `organisation-id` | The RSD organisation UUID to show items for      | Netherlands eScience Center organisation |
 | `limit`           | Number of items to show at initial page load     | `48`                                     |
 
-Note: the shortcode only works in post or page content (not in widgets or template files), since the plugin's assets are only loaded when the shortcode is detected in the content.
+Note: only one `[research_software_directory]` shortcode per page is supported; any further occurrences render a notice instead of a second overview. The shortcode works in post and page content, and also in widgets and template files (where the plugin styles load in the footer).
 
 ### Plugin settings
 

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -40,6 +40,13 @@ class Plugin {
 	private static $instance = null;
 
 	/**
+	 * Whether the shortcode has already been rendered on this page.
+	 *
+	 * @var bool
+	 */
+	private static $shortcode_rendered = false;
+
+	/**
 	 * Get the singleton instance of the class.
 	 *
 	 * @since 0.3.2
@@ -207,6 +214,14 @@ class Plugin {
 		if ( is_admin() ) {
 			return;
 		}
+
+		// Only one shortcode per page is supported: the JS front end binds to a
+		// single container element, so further instances would render as
+		// non-functional HTML with a duplicate id.
+		if ( self::$shortcode_rendered ) {
+			return '<p class="rsd-wordpress-notice">' . esc_html__( 'Only one Research Software Directory shortcode per page is supported.', 'rsd-wordpress' ) . '</p>';
+		}
+		self::$shortcode_rendered = true;
 
 		// Merge default attributes with attributes used in shortcode.
 		$atts = shortcode_atts(

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -25,33 +25,6 @@ class Settings {
 	private static $defaults = array();
 
 	/**
-	 * The single instance of the class.
-	 *
-	 * @var Settings|null
-	 */
-	private static $instance = null;
-
-	/**
-	 * Get the singleton instance of the class.
-	 *
-	 * @return Settings
-	 */
-	public static function get_instance() {
-		if ( null === self::$instance ) {
-			self::$instance = new self();
-		}
-
-		return self::$instance;
-	}
-
-	/**
-	 * Constructor.
-	 */
-	private function __construct() {
-		// Do nothing (yet).
-	}
-
-	/**
 	 * Get the default settings.
 	 *
 	 * @param string|null $key The settings key.

--- a/includes/controller/class-api.php
+++ b/includes/controller/class-api.php
@@ -38,32 +38,10 @@ class Api {
 	private static $version = 'v1';
 
 	/**
-	 * The single instance of the class.
-	 *
-	 * @var Api|null
-	 */
-	private static $instance = null;
-
-	/**
-	 * Get the singleton instance of the class.
-	 *
-	 * @since 0.3.2
-	 * @access public
-	 * @return Api
-	 */
-	public static function get_instance() {
-		if ( null === self::$instance ) {
-			self::$instance = new self();
-		}
-
-		return self::$instance;
-	}
-
-	/**
-	 * Constructor.
+	 * Constructor (private: this class is used statically).
 	 *
 	 * @since 0.0.1
-	 * @access public
+	 * @access private
 	 */
 	private function __construct() {
 	}

--- a/includes/controller/class-controller.php
+++ b/includes/controller/class-controller.php
@@ -113,27 +113,6 @@ class Controller {
 	private static $result_items = false;
 
 	/**
-	 * The instance of the Controller class.
-	 *
-	 * @var Controller|null
-	 */
-	private static $instance = null;
-
-	/**
-	 * Get the instance of the Controller class.
-	 *
-	 * @since 0.3.2
-	 * @return Controller
-	 */
-	public static function get_instance() {
-		if ( null === self::$instance ) {
-			self::$instance = new self();
-		}
-
-		return self::$instance;
-	}
-
-	/**
 	 * Set the section to display.
 	 *
 	 * @param string $section The section to display.

--- a/includes/public/class-display.php
+++ b/includes/public/class-display.php
@@ -22,27 +22,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class Display {
 	/**
-	 * The single instance of the class.
-	 *
-	 * @var Display|null
-	 */
-	private static $instance = null;
-
-	/**
-	 * Get the singleton instance of the class.
-	 *
-	 * @since 0.3.2
-	 * @return Display
-	 */
-	public static function get_instance() {
-		if ( null === self::$instance ) {
-			self::$instance = new self();
-		}
-
-		return self::$instance;
-	}
-
-	/**
 	 * Renders all components: search bar, results settings, filter sidebar and results.
 	 *
 	 * @param array $items The items to display.


### PR DESCRIPTION
This PR drops support for multiple shortcode instances per page, since the aim of the plugin at this point is a single render of projects or software per page. So rather than refactoring the static `Controller` to instance state, a single use per page is now the explicit, enforced contract.

## Changes

- A second `[research_software_directory]` shortcode on the same page now renders a translatable notice. Previously it produced dead HTML: a duplicate `#rsd-wordpress` id, only the first container got working JS, and the second `wp_localize_script` call overwrote the first one's data.
- Removed the singleton boilerplate from `Controller`, `Api`, `Display` and `Settings`: each had a `get_instance()` never called anywhere, while all real access goes through static methods. Only `Plugin` and `Settings_Admin` actually use their singleton.
- README now documents the one-shortcode-per-page limitation, and no longer claims the shortcode doesn't work in widgets and template files (it does, since the asset loading fallback in version 1.3.1).

## Testing

`composer run lint` passes. Verified live on local WordPress install with test page containing two shortcodes: the page serves exactly one `#rsd-wordpress` container, the first shortcode renders its result cards, and the second renders the notice. The regular single shortcode page renders unchanged.